### PR TITLE
Update chart to support current edge

### DIFF
--- a/charts/quickwit/Chart.yaml
+++ b/charts/quickwit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: quickwit
 description: Open-Source & Cloud-Native Log Management at any scale.
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: "edge"
 keywords:
 - quickwit

--- a/charts/quickwit/templates/_helpers.tpl
+++ b/charts/quickwit/templates/_helpers.tpl
@@ -67,6 +67,14 @@ app.kubernetes.io/component: indexer
 {{- end }}
 
 {{/*
+Metastore Selector labels
+*/}}
+{{- define "quickwit.metastore.selectorLabels" -}}
+{{ include "quickwit.selectorLabels" . }}
+app.kubernetes.io/component: metastore
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "quickwit.serviceAccountName" -}}
@@ -114,8 +122,10 @@ Quickwit environment
 - name: QW_S3_ENDPOINT
   value: {{ .Values.config.s3.endpoint }}
 {{- end }}
+{{- if .Values.config.s3.region }}
 - name: AWS_REGION
-  value: {{ .Values.config.s3.endpoint | default "us-east-1" }}
+  value: {{ .Values.config.s3.region }}
+{{- end }}
 - name: AWS_ACCESS_KEY_ID
   value: {{ required "A valid config.s3.access_key is required!" .Values.config.s3.access_key }}
 - name: AWS_SECRET_ACCESS_KEY
@@ -127,7 +137,7 @@ Quickwit environment
   value: "$(POD_NAME)"
 - name: QW_PEER_SEEDS
   value: {{ include "quickwit.fullname" . }}-headless
-- name: QW_PUBLIC_IP
+- name: QW_ADVERTISE_ADDRESS
   value: "$(POD_IP)"
 {{- range $key, $value := .Values.environment }}
 - name: "{{ $key }}"

--- a/charts/quickwit/templates/metastore-deployment.yaml
+++ b/charts/quickwit/templates/metastore-deployment.yaml
@@ -1,17 +1,15 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: {{ include "quickwit.fullname" . }}-metastore
   labels:
     {{- include "quickwit.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.metastore.replicaCount }}
-  serviceName: {{ include "quickwit.fullname" . }}-headless
   selector:
     matchLabels:
       {{- include "quickwit.metastore.selectorLabels" . | nindent 6 }}
-  updateStrategy:
-    {{- toYaml .Values.metastore.updateStrategy | nindent 4 }}
+  strategy: {{- toYaml .Values.metastore.strategy | nindent 4 }}
   template:
     metadata:
       annotations:

--- a/charts/quickwit/templates/metastore-statefulset.yaml
+++ b/charts/quickwit/templates/metastore-statefulset.yaml
@@ -1,17 +1,17 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "quickwit.fullname" . }}-indexer
+  name: {{ include "quickwit.fullname" . }}-metastore
   labels:
     {{- include "quickwit.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.indexer.replicaCount }}
+  replicas: {{ .Values.metastore.replicaCount }}
   serviceName: {{ include "quickwit.fullname" . }}-headless
   selector:
     matchLabels:
-      {{- include "quickwit.indexer.selectorLabels" . | nindent 6 }}
+      {{- include "quickwit.metastore.selectorLabels" . | nindent 6 }}
   updateStrategy:
-    {{- toYaml .Values.indexer.updateStrategy | nindent 4 }}
+    {{- toYaml .Values.metastore.updateStrategy | nindent 4 }}
   template:
     metadata:
       annotations:
@@ -20,7 +20,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "quickwit.indexer.selectorLabels" . | nindent 8 }}
+        {{- include "quickwit.metastore.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -37,11 +37,11 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             {{- include "quickwit.environment" . | nindent 12 }}
-            {{- range $key, $value := .Values.indexer.extraEnv }}
+            {{- range $key, $value := .Values.metastore.extraEnv }}
             - name: "{{ $key }}"
               value: "{{ $value }}"
             {{- end }}
-          args: ["run", "--service", "indexer"]
+          args: ["run", "--service", "metastore"]
           ports:
             - name: http
               containerPort: 7280
@@ -53,9 +53,9 @@ spec:
               containerPort: 7282
               protocol: UDP
           livenessProbe:
-            {{- toYaml .Values.indexer.livenessProbe | nindent 12 }}
+            {{- toYaml .Values.metastore.livenessProbe | nindent 12 }}
           readinessProbe:
-            {{- toYaml .Values.indexer.readinessProbe | nindent 12 }}
+            {{- toYaml .Values.metastore.readinessProbe | nindent 12 }}
           volumeMounts:
             - name: config
               mountPath: /quickwit/node.yaml

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -2,8 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
-
 image:
   repository: quickwit/quickwit
   pullPolicy: IfNotPresent
@@ -75,6 +73,7 @@ searcher:
       port: http
 
 indexer:
+  replicaCount: 1
 
   # Extra env for indexer
   extraEnv: {}
@@ -106,6 +105,35 @@ indexer:
       path: /
       port: http
 
+metastore:
+  replicaCount: 1
+
+  # Extra env for metastore
+  extraEnv: {}
+    # KEY: VALUE
+
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  updateStrategy: {}
+    # type: RollingUpdate
+
+  livenessProbe:
+    httpGet:
+      path: /
+      port: http
+
+  readinessProbe:
+    httpGet:
+      path: /
+      port: http
+
+
 # Quickwit configuration
 config:
   postgres:
@@ -116,7 +144,7 @@ config:
     password: ""
   s3:
     endpoint: ""
-    region: us-east-1
+    # region: us-east-1
     access_key: ""
     secret_key: ""
   default_index_root_uri: s3://quickwit/indexes

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -120,8 +120,11 @@ metastore:
     #   cpu: 100m
     #   memory: 128Mi
 
-  updateStrategy: {}
-    # type: RollingUpdate
+  strategy:
+    type: RollingUpdate
+    # rollingUpdate:
+    #   maxUnavailable: 5%
+    #   maxSurge: 25%
 
   livenessProbe:
     httpGet:


### PR DESCRIPTION
Update chart to work with current edge release that includes metastore:

```
{
  "commit_version_tag": "none",
  "cargo_pkg_version": "0.3.1",
  "cargo_build_target": "x86_64-unknown-linux-gnu",
  "commit_short_hash": "e9f4839fc",
  "commit_date": "2022-09-08",
  "version": "0.3.1-nightly"
}
```