### PR TITLE
add metastore_uri

### DIFF
--- a/charts/quickwit/templates/_helpers.tpl
+++ b/charts/quickwit/templates/_helpers.tpl
@@ -204,6 +204,6 @@ Quickwit metastore environment
   {{ if and .Values.config.postgres .Values.config.metastore_uri }}
     {{ fail "Invalid Config: Metastore cannot be both s3 and postgres"}}
   {{ else if and (not .Values.config.postgres) (not .Values.config.metastore_uri) }}
-    {{ fail "Invalid Config: Metastore must be either have metastore_uri or s3"}}
+    {{ fail "Invalid Config: Metastore must be either have metastore_uri or postgres"}}
   {{ end }}
 {{ end }}

--- a/charts/quickwit/templates/_helpers.tpl
+++ b/charts/quickwit/templates/_helpers.tpl
@@ -200,3 +200,10 @@ Quickwit metastore environment
 {{- end }}
 {{- end }}
 
+{{- define "quickwit.metastore.error.invalid_metastore_datastore" -}}
+  {{ if and .Values.config.postgres .Values.config.metastore_uri }}
+    {{ fail "Invalid Config: Metastore cannot be both s3 and postgres"}}
+  {{ else if and (not .Values.config.postgres) (not .Values.config.metastore_uri) }}
+    {{ fail "Invalid Config: Metastore must be either have metastore_uri or s3"}}
+  {{ end }}
+{{ end }}

--- a/charts/quickwit/templates/configmap.yaml
+++ b/charts/quickwit/templates/configmap.yaml
@@ -11,6 +11,7 @@ data:
     listen_address: 0.0.0.0
     gossip_listen_port: 7282
     data_dir: /quickwit/qwdata
+    metastore_uri: {{ .Values.config.metastore_uri }}
     default_index_root_uri: {{ .Values.config.default_index_root_uri }}
     {{- with .Values.config.indexer }}
     indexer:

--- a/charts/quickwit/templates/configmap.yaml
+++ b/charts/quickwit/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{ include "quickwit.metastore.error.invalid_metastore_datastore" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,7 +12,9 @@ data:
     listen_address: 0.0.0.0
     gossip_listen_port: 7282
     data_dir: /quickwit/qwdata
+    {{- if and .Values.config.s3 .Values.config.metastore_uri }}]
     metastore_uri: {{ .Values.config.metastore_uri }}
+    {{- end }}
     default_index_root_uri: {{ .Values.config.default_index_root_uri }}
     {{- with .Values.config.indexer }}
     indexer:

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -306,6 +306,7 @@ bootstrap:
 # Quickwit configuration
 config:
   # Metastore configuration.
+  metastore_uri: s3://quickwit/indexes
   postgres: {}
   #   host: ""
   #   port: 5432
@@ -321,8 +322,6 @@ config:
 
   azure_blob: {}
     # access_key: "my-azure-blob-access-key"
-
-  metastore_uri: s3://quickwit/indexes
 
   default_index_root_uri: s3://quickwit/indexes
   # Indexer settings

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -322,6 +322,8 @@ config:
   azure_blob: {}
     # access_key: "my-azure-blob-access-key"
 
+  metastore_uri: s3://quickwit/indexes
+
   default_index_root_uri: s3://quickwit/indexes
   # Indexer settings
   # indexer:


### PR DESCRIPTION
This adds:
- metastore_uri as per the [doc](https://quickwit.io/docs/guides/storage-setup/aws-s3) suggestion.
- Conditional check if postgres and metastore_uri are defined

Outputs:
```yaml
# Source: quickwit/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: test-quickwit
  labels:
    helm.sh/chart: quickwit-0.3.4
    app.kubernetes.io/name: quickwit
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "v0.5.0"
    app.kubernetes.io/managed-by: Helm
data:
  node.yaml: |-
    version: 0.4
    cluster_id: test-quickwit
    listen_address: 0.0.0.0
    gossip_listen_port: 7282
    data_dir: /quickwit/qwdata
    metastore_uri: s3://quickwit/indexes
    default_index_root_uri: s3://quickwit/indexes
 ```