### PR TITLE
Fix azure storage setup

### DIFF
--- a/charts/quickwit/templates/_helpers.tpl
+++ b/charts/quickwit/templates/_helpers.tpl
@@ -159,8 +159,12 @@ Quickwit environment
       key: s3.secret_key
 {{- end }}
 {{- end }}
+{{- if .Values.config.azure_blob.account_name }}
+- name: QW_AZURE_STORAGE_ACCOUNT
+  value: {{ .Values.config.azure_blob.account_name }}
+{{- end }}
 {{- if .Values.config.azure_blob.access_key }}
-- name: QW_AZURE_ACCESS_KEY
+- name: QW_AZURE_STORAGE_ACCESS_KEY
   valueFrom:
     secretKeyRef:
       name: {{ include "quickwit.fullname" $ }}

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -6,7 +6,7 @@ image:
   repository: quickwit/quickwit
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  # tag: v0.5.0
+  # tag: v0.6.0
 
 imagePullSecrets: []
 nameOverride: ""
@@ -320,6 +320,7 @@ config:
     # secret_key: "my-secret-key"
 
   azure_blob: {}
+    # account_name: "my-azure-blob-accout"
     # access_key: "my-azure-blob-access-key"
 
   default_index_root_uri: s3://quickwit/indexes


### PR DESCRIPTION
The setup of azure storage is broken in the helm charts when updating to quickwit 0.6