### PR TITLE
Do not use secret from values file

### DIFF
--- a/charts/quickwit/Chart.yaml
+++ b/charts/quickwit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: quickwit
 description: Sub-second search & analytics engine on cloud storage.
 type: application
-version: 0.5.3
+version: 0.6.0
 appVersion: "v0.7.0"
 keywords:
   - quickwit

--- a/charts/quickwit/templates/control-plane-deployment.yaml
+++ b/charts/quickwit/templates/control-plane-deployment.yaml
@@ -41,6 +41,10 @@ spec:
             - name: "{{ $key }}"
               value: "{{ $value }}"
             {{- end }}
+          {{- with .Values.control_plane.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             {{- include "quickwit.ports" . | nindent 12 }}
           startupProbe:

--- a/charts/quickwit/templates/indexer-statefulset.yaml
+++ b/charts/quickwit/templates/indexer-statefulset.yaml
@@ -44,6 +44,10 @@ spec:
             - name: "{{ $key }}"
               value: "{{ $value }}"
             {{- end }}
+          {{- with .Values.indexer.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           args: ["run", "--service", "indexer"]
           ports:
             {{- include "quickwit.ports" . | nindent 12 }}

--- a/charts/quickwit/templates/janitor-deployment.yaml
+++ b/charts/quickwit/templates/janitor-deployment.yaml
@@ -42,6 +42,10 @@ spec:
             - name: "{{ $key }}"
               value: "{{ $value }}"
             {{- end }}
+          {{- with .Values.janitor.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             {{- include "quickwit.ports" . | nindent 12 }}
           startupProbe:

--- a/charts/quickwit/templates/job-create-indices.yaml
+++ b/charts/quickwit/templates/job-create-indices.yaml
@@ -42,6 +42,10 @@ spec:
           - name: "{{ $key }}"
             value: "{{ $value }}"
           {{- end }}
+        {{- with .Values.bootstrap.extraEnvFrom }}
+        envFrom:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
         volumeMounts:
           - name: config
             mountPath: /quickwit/node.yaml

--- a/charts/quickwit/templates/job-create-sources.yaml
+++ b/charts/quickwit/templates/job-create-sources.yaml
@@ -42,6 +42,10 @@ spec:
           - name: "{{ $key }}"
             value: "{{ $value }}"
           {{- end }}
+        {{- with .Values.bootstrap.extraEnvFrom }}
+        envFrom:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
         volumeMounts:
           - name: config
             mountPath: /quickwit/node.yaml

--- a/charts/quickwit/templates/metastore-deployment.yaml
+++ b/charts/quickwit/templates/metastore-deployment.yaml
@@ -40,6 +40,10 @@ spec:
             - name: "{{ $key }}"
               value: "{{ $value }}"
             {{- end }}
+          {{- with .Values.metastore.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             {{- include "quickwit.ports" . | nindent 12 }}
           startupProbe:

--- a/charts/quickwit/templates/searcher-statefulset.yaml
+++ b/charts/quickwit/templates/searcher-statefulset.yaml
@@ -44,6 +44,10 @@ spec:
             - name: "{{ $key }}"
               value: "{{ $value }}"
             {{- end }}
+          {{- with .Values.searcher.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           args: ["run", "--service", "searcher"]
           ports:
             {{- include "quickwit.ports" . | nindent 12 }}

--- a/charts/quickwit/templates/secret.yaml
+++ b/charts/quickwit/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.existingSecretForConfig -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -14,4 +15,5 @@ data:
 {{- end }}
 {{- if ((.Values.config.storage).azure).access_key }}
   storage.azure.access_key: {{ .Values.config.storage.azure.access_key | b64enc | quote }}
+{{- end }}
 {{- end }}

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -39,7 +39,7 @@ environment: {}
   # KEY: VALUE
 
 # -- Specify an existing secret containing Quickwit configuration.
-existingSecretForConfig: ""
+existingSecretForConfig: false
 
 searcher:
   replicaCount: 3

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -159,7 +159,7 @@ metastore:
   # Extra env for metastore
   extraEnv: {}
     # KEY: VALUE
-  
+
   # -- Environment variables from secrets or configmaps to add to the metastore
   extraEnvFrom: []
   # - secretRef:
@@ -210,7 +210,7 @@ control_plane:
   # Extra env for control plane
   extraEnv: {}
     # KEY: VALUE
-  
+
   # -- Environment variables from secrets or configmaps to add to the control plane
   extraEnvFrom: []
   # - secretRef:
@@ -262,7 +262,7 @@ janitor:
   # Extra env for searcher
   extraEnv: {}
     # KEY: VALUE
-  
+
   # -- Environment variables from secrets or configmaps to add to the janitor
   extraEnvFrom: []
   # - secretRef:
@@ -315,7 +315,7 @@ bootstrap:
   # Extra env for boostrap jobs
   extraEnv: {}
     # KEY: VALUE
-  
+
   # -- Environment variables from secrets or configmaps to add to the bootstrap
   extraEnvFrom: []
   # - secretRef:

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -38,12 +38,20 @@ securityContext:
 environment: {}
   # KEY: VALUE
 
+# -- Specify an existing secret containing Quickwit configuration.
+existingSecretForConfig: ""
+
 searcher:
   replicaCount: 3
 
   # Extra env for searcher
   extraEnv: {}
     # KEY: VALUE
+
+  # -- Environment variables from secrets or configmaps to add to the searcher
+  extraEnvFrom: []
+  # - secretRef:
+  #     name: quickwit-credentials
 
   resources: {}
     # limits:
@@ -96,6 +104,11 @@ indexer:
   extraEnv: {}
     # KEY: VALUE
 
+  # -- Environment variables from secrets or configmaps to add to the indexer
+  extraEnvFrom: []
+  # - secretRef:
+  #     name: quickwit-credentials
+
   resources: {}
     # limits:
     #   cpu: 100m
@@ -146,6 +159,11 @@ metastore:
   # Extra env for metastore
   extraEnv: {}
     # KEY: VALUE
+  
+  # -- Environment variables from secrets or configmaps to add to the metastore
+  extraEnvFrom: []
+  # - secretRef:
+  #     name: quickwit-credentials
 
   resources: {}
     # limits:
@@ -192,6 +210,11 @@ control_plane:
   # Extra env for control plane
   extraEnv: {}
     # KEY: VALUE
+  
+  # -- Environment variables from secrets or configmaps to add to the control plane
+  extraEnvFrom: []
+  # - secretRef:
+  #     name: quickwit-credentials
 
   resources: {}
     # limits:
@@ -239,6 +262,11 @@ janitor:
   # Extra env for searcher
   extraEnv: {}
     # KEY: VALUE
+  
+  # -- Environment variables from secrets or configmaps to add to the janitor
+  extraEnvFrom: []
+  # - secretRef:
+  #     name: quickwit-credentials
 
   resources: {}
     # limits:
@@ -287,6 +315,11 @@ bootstrap:
   # Extra env for boostrap jobs
   extraEnv: {}
     # KEY: VALUE
+  
+  # -- Environment variables from secrets or configmaps to add to the bootstrap
+  extraEnvFrom: []
+  # - secretRef:
+  #     name: quickwit-credentials
 
   resources: {}
     # limits:


### PR DESCRIPTION
I would like to store S3 credentials and PostgreSQL password into an external secret file and not use the `values.yaml` file.

We could do that like that:

```yaml
# -- Specify an existing secret containing Quickwit configuration.
existingSecretForConfig: true

searcher:
  extraEnvFrom:
    - secretRef:
        name: quickwit-credentials

indexer:
  extraEnvFrom:
    - secretRef:
        name: quickwit-credentials

metastore:
  extraEnvFrom:
    - secretRef:
        name: quickwit-credentials

control_plane:
  extraEnvFrom:
    - secretRef:
        name: quickwit-credentials

janitor:
  extraEnvFrom:
    - secretRef:
        name: quickwit-credentials

bootstrap:
  extraEnvFrom:
    - secretRef:
        name: quickwit-credentials

```

and the outputs:

```yaml
# Source: quickwit/templates/searcher-statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: release-name-quickwit-searcher
  labels:
    helm.sh/chart: quickwit-0.6.0
    app.kubernetes.io/name: quickwit
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v0.7.0"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 3
  serviceName: release-name-quickwit-headless
  selector:
    matchLabels:
      app.kubernetes.io/name: quickwit
      app.kubernetes.io/instance: release-name
      app.kubernetes.io/component: searcher
  template:
    metadata:
      annotations:
        checksum/config: c6e241d5c75458b6f77c0e7d804947734cb320eb74667a4d795ba40c52a3392e
      labels:
        app.kubernetes.io/name: quickwit
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/component: searcher
    spec:
      serviceAccountName: release-name-quickwit
      securityContext:
        fsGroup: 1005
      containers:
        - name: quickwit
          securityContext:
            runAsNonRoot: true
            runAsUser: 1005
          image: "quickwit/quickwit:v0.7.0"
          imagePullPolicy: IfNotPresent
          env:
            - name: NAMESPACE
              valueFrom:
                fieldRef:
                  fieldPath: metadata.namespace
            - name: POD_NAME
              valueFrom:
                fieldRef:
                  fieldPath: metadata.name
            - name: POD_IP
              valueFrom:
                fieldRef:
                  fieldPath: status.podIP
            - name: QW_CONFIG
              value: node.yaml
            - name: QW_CLUSTER_ID
              value: default-release-name-quickwit
            - name: QW_NODE_ID
              value: "$(POD_NAME)"
            - name: QW_PEER_SEEDS
              value: release-name-quickwit-headless
            - name: QW_ADVERTISE_ADDRESS
              value: "$(POD_IP)"
          envFrom:
            - secretRef:
                name: quickwit-credentials
          args: ["run", "--service", "searcher"]
...
```

Linked to #48 
