### PR TITLE
fix: Truncate Job Name for long index/source name

### DIFF
--- a/charts/quickwit/Chart.yaml
+++ b/charts/quickwit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: quickwit
 description: Sub-second search & analytics engine on cloud storage.
 type: application
-version: 0.5.4
+version: 0.5.5
 appVersion: "v0.7.1"
 keywords:
   - quickwit

--- a/charts/quickwit/templates/job-create-indices.yaml
+++ b/charts/quickwit/templates/job-create-indices.yaml
@@ -4,7 +4,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "quickwit.fullname" $ }}-index-{{ .index_id }}
+  name: {{ printf "%s-index-%s" (include "quickwit.fullname" $ | trunc 47) .index_id | trunc 63 |  trimSuffix "-" }}
   labels:
     {{- include "quickwit.labels" $ | nindent 4 }}
   annotations:

--- a/charts/quickwit/templates/job-create-sources.yaml
+++ b/charts/quickwit/templates/job-create-sources.yaml
@@ -4,7 +4,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "quickwit.fullname" $ }}-source-{{ .source.source_id }}
+  name: {{ printf "%s-source-%s" (include "quickwit.fullname" $ | trunc 46) .source.source_id | trunc 63 | trimSuffix "-" }}
   labels:
     {{- include "quickwit.labels" $ | nindent 4 }}
   annotations:


### PR DESCRIPTION
There is the Kubernets limit for Job Name, it's truncates to proper limit.