### PR TITLE
Add janitor/control plane services, cleanup.

### DIFF
--- a/charts/quickwit/Chart.yaml
+++ b/charts/quickwit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: quickwit
 description: Sub-second search & analytics engine on cloud storage.
 type: application
-version: 0.5.4
+version: 0.5.5
 appVersion: "v0.7.1"
 keywords:
   - quickwit

--- a/charts/quickwit/templates/control-plane-deployment.yaml
+++ b/charts/quickwit/templates/control-plane-deployment.yaml
@@ -10,7 +10,7 @@ spec:
     matchLabels:
       {{- include "quickwit.control_plane.selectorLabels" . | nindent 6 }}
   strategy:
-    {{- toYaml .Values.control_plane.updateStrategy | nindent 4 }}      
+    type: Recreate
   template:
     metadata:
       annotations:

--- a/charts/quickwit/templates/janitor-deployment.yaml
+++ b/charts/quickwit/templates/janitor-deployment.yaml
@@ -11,7 +11,7 @@ spec:
     matchLabels:
       {{- include "quickwit.janitor.selectorLabels" . | nindent 6 }}
   strategy:
-    {{- toYaml .Values.janitor.updateStrategy | nindent 4 }}      
+    type: Recreate
   template:
     metadata:
       annotations:

--- a/charts/quickwit/templates/service.yaml
+++ b/charts/quickwit/templates/service.yaml
@@ -71,4 +71,42 @@ spec:
       name: grpc
   selector:
     {{- include "quickwit.metastore.selectorLabels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "quickwit.fullname" . }}-control-plane
+  labels:
+    {{- include "quickwit.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: 7280
+      targetPort: rest
+      protocol: TCP
+      name: rest
+    - port: 7281
+      targetPort: grpc
+      name: grpc
+  selector:
+    {{- include "quickwit.control_plane.selectorLabels" . | nindent 4 }}
 
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "quickwit.fullname" . }}-janitor
+  labels:
+    {{- include "quickwit.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: 7280
+      targetPort: rest
+      protocol: TCP
+      name: rest
+    - port: 7281
+      targetPort: grpc
+      name: grpc
+  selector:
+    {{- include "quickwit.janitor.selectorLabels" . | nindent 4 }}

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -283,8 +283,12 @@ bootstrap:
 # Quickwit configuration
 config:
   # Metastore configuration.
-  metastore_uri: s3://quickwit/indexes
-  # postgres: {}
+  # Default to `qwdata/indexes` if not set.
+  # S3 metastore
+  # metastore_uri: s3://quickwit/indexes
+  #
+  # Postgres metastore
+  # postgres:
   #   host: ""
   #   port: 5432
   #   database: metastore
@@ -292,6 +296,7 @@ config:
   #   password: ""
   #   max_num_connections: 50
 
+  # Storage configuration.
   # storage:
     # s3:
       # endpoint: "http://custom-s3-endpoint"
@@ -305,6 +310,7 @@ config:
       # access_key: "my-azure-blob-access-key"
 
   default_index_root_uri: s3://quickwit/indexes
+
   # Indexer settings
   # indexer:
   #   split_store_max_num_bytes: 200G

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -155,11 +155,6 @@ metastore:
     #   cpu: 100m
     #   memory: 128Mi
 
-  ## Pod distruption budget
-  podDisruptionBudget: {}
-    # maxUnavailable: 1
-    # minAvailable: 2
-
   updateStrategy: {}
     # type: RollingUpdate
 
@@ -187,8 +182,6 @@ metastore:
   affinity: {}
 
 control_plane:
-  replicaCount: 1
-
   # Extra env for control plane
   extraEnv: {}
     # KEY: VALUE
@@ -200,14 +193,6 @@ control_plane:
     # requests:
     #   cpu: 100m
     #   memory: 128Mi
-
-  ## Pod distruption budget
-  podDisruptionBudget: {}
-    # maxUnavailable: 1
-    # minAvailable: 2
-
-  updateStrategy: {}
-    # type: RollingUpdate
 
   startupProbe:
     httpGet:
@@ -247,14 +232,6 @@ janitor:
     # requests:
     #   cpu: 100m
     #   memory: 128Mi
-
-  ## Pod distruption budget
-  podDisruptionBudget: {}
-    # maxUnavailable: 1
-    # minAvailable: 2
-
-  updateStrategy: {}
-    # type: RollingUpdate
 
   startupProbe:
     httpGet:
@@ -306,7 +283,8 @@ bootstrap:
 # Quickwit configuration
 config:
   # Metastore configuration.
-  postgres: {}
+  metastore_uri: s3://quickwit/indexes
+  # postgres: {}
   #   host: ""
   #   port: 5432
   #   database: metastore


### PR DESCRIPTION
```
k get svc

NAME                                  TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                         AGE
qw-gharchive-quickwit-control-plane   NodePort    172.20.146.158   <none>        7280:32159/TCP,7281:30186/TCP   6m56s
qw-gharchive-quickwit-headless        ClusterIP   None             <none>        7282/UDP                        6m56s
qw-gharchive-quickwit-indexer         NodePort    172.20.225.155   <none>        7280:31993/TCP,7281:32264/TCP   6m56s
qw-gharchive-quickwit-janitor         NodePort    172.20.7.94      <none>        7280:30004/TCP,7281:31495/TCP   6m56s
qw-gharchive-quickwit-metastore       NodePort    172.20.138.136   <none>        7280:31656/TCP,7281:31392/TCP   6m56s
qw-gharchive-quickwit-searcher        NodePort    172.20.126.208   <none>        7280:32179/TCP,7281:32017/TCP   6m56s

```