### PR TITLE
modify storage config in configmap

### DIFF
--- a/charts/quickwit/Chart.yaml
+++ b/charts/quickwit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: quickwit
 description: Sub-second search & analytics engine on cloud storage.
 type: application
-version: 0.5.7
+version: 0.5.8
 appVersion: "v0.7.1"
 keywords:
   - quickwit

--- a/charts/quickwit/templates/configmap.yaml
+++ b/charts/quickwit/templates/configmap.yaml
@@ -16,19 +16,8 @@ data:
       {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- with .Values.config.storage }}
-    {{- $new_storage := . | deepCopy }}
-    {{- /* s3 access_key_id and secret_access_key are already set by env variables */}}
-    {{ if .s3 }}
-    {{- $_ := set $new_storage.s3 "access_key_id" "${AWS_ACCESS_KEY_ID}" }}
-    {{- $_ := set $new_storage.s3 "secret_access_key" "${AWS_SECRET_ACCESS_KEY}" }}
-    {{- end }}
-    {{- /* azure account and access_key are already set by env variables */}}
-    {{ if .azure }}
-    {{- $_ := set $new_storage.azure "account" "${QW_AZURE_STORAGE_ACCOUNT}" }}
-    {{- $_ := set $new_storage.azure "access_key" "${QW_AZURE_STORAGE_ACCESS_KEY}" }}
-    {{- end }}
     storage:
-      {{- toYaml $new_storage | nindent 6 }}
+      {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- with .Values.config.ingest_api }}
     ingest_api:


### PR DESCRIPTION
Previously we were copying the storage config and set `access_key_id` and `secret_access_key` from environment variables, and if the env variables were not set, this was causing the pods to crash as the values are not set with below logs 

```
quickwit-searcher-0 quickwit     failed to render config file template: environment variable `AWS_ACCESS_KEY_ID` is not set and no default value is provided
```