### PR TITLE
Custom pod labels

### DIFF
--- a/charts/quickwit/Chart.yaml
+++ b/charts/quickwit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: quickwit
 description: Sub-second search & analytics engine on cloud storage.
 type: application
-version: 0.5.10
+version: 0.5.11
 appVersion: "v0.8.1"
 keywords:
   - quickwit

--- a/charts/quickwit/templates/_helpers.tpl
+++ b/charts/quickwit/templates/_helpers.tpl
@@ -54,7 +54,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-Search Selector labels
+Searcher Selector labels
 */}}
 {{- define "quickwit.searcher.selectorLabels" -}}
 {{ include "quickwit.selectorLabels" . }}
@@ -200,4 +200,3 @@ Quickwit metastore environment
   value: "postgres://$(POSTGRES_USERNAME):$(POSTGRES_PASSWORD)@$(POSTGRES_HOST):$(POSTGRES_PORT)/$(POSTGRES_DATABASE)"      
 {{- end }}
 {{- end }}
-

--- a/charts/quickwit/templates/control-plane-deployment.yaml
+++ b/charts/quickwit/templates/control-plane-deployment.yaml
@@ -19,6 +19,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
+        {{- include "quickwit.labels" . | nindent 8 }}
         {{- include "quickwit.control_plane.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
@@ -78,4 +79,3 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-

--- a/charts/quickwit/templates/indexer-statefulset.yaml
+++ b/charts/quickwit/templates/indexer-statefulset.yaml
@@ -23,6 +23,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
+        {{- include "quickwit.labels" . | nindent 8 }}
         {{- include "quickwit.indexer.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}

--- a/charts/quickwit/templates/janitor-deployment.yaml
+++ b/charts/quickwit/templates/janitor-deployment.yaml
@@ -20,6 +20,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
+        {{- include "quickwit.labels" . | nindent 8 }}
         {{- include "quickwit.janitor.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}

--- a/charts/quickwit/templates/metastore-deployment.yaml
+++ b/charts/quickwit/templates/metastore-deployment.yaml
@@ -18,6 +18,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
+        {{- include "quickwit.labels" . | nindent 8 }}
         {{- include "quickwit.metastore.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}

--- a/charts/quickwit/templates/searcher-statefulset.yaml
+++ b/charts/quickwit/templates/searcher-statefulset.yaml
@@ -23,6 +23,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
+        {{- include "quickwit.labels" . | nindent 8 }}
         {{- include "quickwit.searcher.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -45,6 +45,9 @@ searcher:
   extraEnv: {}
     # KEY: VALUE
 
+  podExtraLabels: {}
+    # KEY: VALUE
+
   resources: {}
     # limits:
     #   cpu: 100m

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -45,9 +45,6 @@ searcher:
   extraEnv: {}
     # KEY: VALUE
 
-  podExtraLabels: {}
-    # KEY: VALUE
-
   resources: {}
     # limits:
     #   cpu: 100m


### PR DESCRIPTION
We want the pod labels to be customizable.

The solution proposed here uses the common labels on pods (instead of the selector labels only) so that the `additionalLabels` value also appears on pods.