### PR TITLE
Clean unused monitoring service additionalLabels value

### DIFF
--- a/charts/quickwit/Chart.yaml
+++ b/charts/quickwit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: quickwit
 description: Sub-second search & analytics engine on cloud storage.
 type: application
-version: 0.5.14
+version: 0.5.15
 appVersion: "v0.8.1"
 keywords:
   - quickwit

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -395,8 +395,6 @@ config:
 # Prometheus metrics
 serviceMonitor:
   enabled: false
-  # -- Additional labels to add to monitoring resources
-  additionalLabels: {}
   interval: 60s
   scrapeTimeout: 10s
   metricRelabelings: []


### PR DESCRIPTION
A quick search in the repo didn't give any match for serviceMonitor.additionalLabels:
- introduced in a buggy way in https://github.com/quickwit-oss/helm-charts/pull/27 
- cleanup up partially a few months later in https://github.com/quickwit-oss/helm-charts/commit/7132cff24fbcc50abe5ef1899891e75753e2a15b