### PR TITLE
Add possibility to specify services type per service

### DIFF
--- a/charts/quickwit/Chart.yaml
+++ b/charts/quickwit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: quickwit
 description: Sub-second search & analytics engine on cloud storage.
 type: application
-version: 0.6.0
+version: 0.6.1
 appVersion: "v0.8.1"
 keywords:
   - quickwit

--- a/charts/quickwit/templates/service.yaml
+++ b/charts/quickwit/templates/service.yaml
@@ -12,7 +12,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ .Values.searcher.serviceType | default .Values.service.type }}
   {{- if .Values.service.ipFamilyPolicy }}
   ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
   {{- end }}
@@ -80,7 +80,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ .Values.indexer.serviceType | default .Values.service.type }}
   {{- if .Values.service.ipFamilyPolicy }}
   ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
   {{- end }}
@@ -112,7 +112,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ .Values.metastore.serviceType | default .Values.service.type }}
   {{- if .Values.service.ipFamilyPolicy }}
   ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
   {{- end }}
@@ -136,8 +136,15 @@ metadata:
   name: {{ include "quickwit.fullname" . }}-control-plane
   labels:
     {{- include "quickwit.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.control_plane.serviceAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ .Values.control_plane.serviceType | default .Values.service.type }}
   {{- if .Values.service.ipFamilyPolicy }}
   ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
   {{- end }}
@@ -162,8 +169,15 @@ metadata:
   name: {{ include "quickwit.fullname" . }}-janitor
   labels:
     {{- include "quickwit.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.janitor.serviceAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ .Values.janitor.serviceType | default .Values.service.type }}
   {{- if .Values.service.ipFamilyPolicy }}
   ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
   {{- end }}

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -105,6 +105,8 @@ searcher:
 
   serviceAnnotations: {}
 
+  # serviceType: ClusterIP
+
   nodeSelector: {}
 
   tolerations: []
@@ -161,6 +163,8 @@ indexer:
   podAnnotations: {}
 
   serviceAnnotations: {}
+
+  # serviceType: ClusterIP
 
   nodeSelector: {}
 
@@ -220,6 +224,8 @@ metastore:
 
   serviceAnnotations: {}
 
+  # serviceType: ClusterIP
+
   nodeSelector: {}
 
   tolerations: []
@@ -264,6 +270,10 @@ control_plane:
   annotations: {}
 
   podAnnotations: {}
+
+  serviceAnnotations: {}
+
+  # serviceType: ClusterIP
 
   nodeSelector: {}
 
@@ -312,6 +322,10 @@ janitor:
   annotations: {}
 
   podAnnotations: {}
+
+  serviceAnnotations: {}
+
+  # serviceType: ClusterIP
 
   nodeSelector: {}
 
@@ -457,6 +471,7 @@ prometheusRule:
   #      severity: warning
 
 service:
+  # Service type configuration default for all Quickwit services
   type: ClusterIP
 
   # -- Set the ip family policy to configure dual-stack see [Configure dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services)


### PR DESCRIPTION
So my use case is to expose only the quickwit indexer through a load balancer. This patch is a bit more general but should get the work done. Haven't had time to test it yet! 