### PR TITLE
Add config.postgres.existingSecret

### DIFF
--- a/charts/quickwit/templates/_helpers.tpl
+++ b/charts/quickwit/templates/_helpers.tpl
@@ -201,7 +201,11 @@ Quickwit metastore environment
 - name: POSTGRES_PASSWORD
   valueFrom:
     secretKeyRef:
+      {{- if .Values.config.postgres.existingSecret }}
+      name: {{ .Values.config.postgres.existingSecret }}
+      {{- else }}
       name: {{ include "quickwit.fullname" . }}
+      {{- end }}
       key: postgres.password
 - name: QW_METASTORE_URI
   value: "postgres://$(POSTGRES_USERNAME):$(POSTGRES_PASSWORD)@$(POSTGRES_HOST):$(POSTGRES_PORT)/$(POSTGRES_DATABASE)"      

--- a/charts/quickwit/templates/secret.yaml
+++ b/charts/quickwit/templates/secret.yaml
@@ -7,7 +7,7 @@ metadata:
 type: Opaque
 data:
 {{- if .Values.config.postgres }}
-  postgres.password: {{ .Values.config.postgres.password | b64enc | quote }}
+  postgres.password: {{ default "" .Values.config.postgres.password | b64enc | quote }}
 {{- end }}
 {{- if ((.Values.config.storage).s3).secret_access_key }}
   storage.s3.secret_access_key: {{ .Values.config.storage.s3.secret_access_key | b64enc | quote }}

--- a/charts/quickwit/templates/secret.yaml
+++ b/charts/quickwit/templates/secret.yaml
@@ -7,7 +7,7 @@ metadata:
 type: Opaque
 data:
 {{- if .Values.config.postgres }}
-  postgres.password: {{ required "A valid config.postgres.password is required!" .Values.config.postgres.password | b64enc | quote }}
+  postgres.password: {{ .Values.config.postgres.password | b64enc | quote }}
 {{- end }}
 {{- if ((.Values.config.storage).s3).secret_access_key }}
   storage.s3.secret_access_key: {{ .Values.config.storage.s3.secret_access_key | b64enc | quote }}

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -327,6 +327,7 @@ config:
   #   username: quickwit
   #   password: ""
   #   max_num_connections: 50
+  #   existingSecret: ""
 
   # Storage configuration.
   # storage:


### PR DESCRIPTION
Small change to allow for using a secret resource that already exists to provide a password for postgres as the metastore.

Forked this for use at my org until something similar is on master, close if you dont want this change.

Thanks,
Max Sargent