### PR TITLE
Fix searcher statefulset volume indentation

### DIFF
--- a/charts/quickwit/templates/searcher-statefulset.yaml
+++ b/charts/quickwit/templates/searcher-statefulset.yaml
@@ -113,7 +113,7 @@ spec:
             name: {{ .name }}
         {{- end }}
         {{- with .Values.searcher.extraVolumes }}
-          {{- toYaml . | nindent 10 }}
+          {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.searcher.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
The indentation for the volume specification on the searcher statefulset was two spaces too many. When specifying `searcher.extraVolumes`, it resulted in:

```
Error: YAML parse error on quickwit/templates/searcher-statefulset.yaml: error converting YAML to JSON: yaml: line 113: did not find expected key
helm.go:84: [debug] error converting YAML to JSON: yaml: line 113: did not find expected key
YAML parse error on quickwit/templates/searcher-statefulset.yaml
helm.sh/helm/v3/pkg/releaseutil.(*manifestFile).sort
        helm.sh/helm/v3/pkg/releaseutil/manifest_sorter.go:146
helm.sh/helm/v3/pkg/releaseutil.SortManifests
        helm.sh/helm/v3/pkg/releaseutil/manifest_sorter.go:106
helm.sh/helm/v3/pkg/action.(*Configuration).renderResources
        helm.sh/helm/v3/pkg/action/action.go:168
helm.sh/helm/v3/pkg/action.(*Install).RunWithContext
        helm.sh/helm/v3/pkg/action/install.go:312
main.runInstall
        helm.sh/helm/v3/cmd/helm/install.go:314
main.newTemplateCmd.func2
        helm.sh/helm/v3/cmd/helm/template.go:95
github.com/spf13/cobra.(*Command).execute
        github.com/spf13/cobra@v1.8.0/command.go:983
github.com/spf13/cobra.(*Command).ExecuteC
        github.com/spf13/cobra@v1.8.0/command.go:1115
github.com/spf13/cobra.(*Command).Execute
        github.com/spf13/cobra@v1.8.0/command.go:1039
main.main
        helm.sh/helm/v3/cmd/helm/helm.go:83
runtime.main
        runtime/proc.go:271
runtime.goexit
        runtime/asm_arm64.s:1222
```

After this fix, this error is resolved and `volumes` is templated as expected.