### PR TITLE
feat: runtimeClassName annotation support so we can support gVisor (GKE Sandbox)

### DIFF
--- a/charts/quickwit/Chart.yaml
+++ b/charts/quickwit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: quickwit
 description: Sub-second search & analytics engine on cloud storage.
 type: application
-version: 0.7.2
+version: 0.7.3
 appVersion: "v0.8.2"
 keywords:
   - quickwit

--- a/charts/quickwit/templates/control-plane-deployment.yaml
+++ b/charts/quickwit/templates/control-plane-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ include "quickwit.fullname" . }}-control-plane
   labels:
-    {{- include "quickwit.labels" . | nindent 4 }}  
+    {{- include "quickwit.labels" . | nindent 4 }}
   annotations:
     {{- with .Values.annotations }}
     {{- toYaml . | nindent 4 }}
@@ -120,4 +120,7 @@ spec:
       {{- with .Values.control_plane.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.control_plane.runtimeClassName }}
+      runtimeClassName: {{ .Values.control_plane.runtimeClassName | quote }}
       {{- end }}

--- a/charts/quickwit/templates/indexer-statefulset.yaml
+++ b/charts/quickwit/templates/indexer-statefulset.yaml
@@ -132,6 +132,9 @@ spec:
       lifecycle:
         {{- toYaml . | nindent 8 }}
       {{- end}}
+      {{- if .Values.indexer.runtimeClassName }}
+      runtimeClassName: {{ .Values.indexer.runtimeClassName | quote }}
+      {{- end }}
   {{- if .Values.indexer.persistentVolume.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/charts/quickwit/templates/janitor-deployment.yaml
+++ b/charts/quickwit/templates/janitor-deployment.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: {{ include "quickwit.fullname" . }}-janitor
   labels:
-    {{- include "quickwit.labels" . | nindent 4 }}  
+    {{- include "quickwit.labels" . | nindent 4 }}
   annotations:
     {{- with .Values.annotations }}
     {{- toYaml . | nindent 4 }}
@@ -122,4 +122,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-{{- end }} 
+      {{- if .Values.janitor.runtimeClassName }}
+      runtimeClassName: {{ .Values.janitor.runtimeClassName | quote }}
+      {{- end }}
+{{- end }}

--- a/charts/quickwit/templates/job-create-indices.yaml
+++ b/charts/quickwit/templates/job-create-indices.yaml
@@ -98,5 +98,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.bootstrap.runtimeClassName }}
+      runtimeClassName: {{ .Values.bootstrap.runtimeClassName | quote }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/quickwit/templates/job-create-sources.yaml
+++ b/charts/quickwit/templates/job-create-sources.yaml
@@ -100,5 +100,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.bootstrap.runtimeClassName }}
+      runtimeClassName: {{ .Values.bootstrap.runtimeClassName | quote }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/quickwit/templates/metastore-deployment.yaml
+++ b/charts/quickwit/templates/metastore-deployment.yaml
@@ -120,3 +120,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.metastore.runtimeClassName }}
+      runtimeClassName: {{ .Values.metastore.runtimeClassName | quote }}
+      {{- end }}

--- a/charts/quickwit/templates/searcher-statefulset.yaml
+++ b/charts/quickwit/templates/searcher-statefulset.yaml
@@ -131,6 +131,9 @@ spec:
       lifecycle:
         {{- toYaml . | nindent 8 }}
       {{- end}}
+      {{- if .Values.searcher.runtimeClassName }}
+      runtimeClassName: {{ .Values.searcher.runtimeClassName | quote }}
+      {{- end }}
   {{- if .Values.searcher.persistentVolume.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -133,6 +133,8 @@ searcher:
 
   affinity: {}
 
+  runtimeClassName: ""
+
 indexer:
   replicaCount: 1
 
@@ -216,6 +218,8 @@ indexer:
   # See https://quickwit.io/docs/configuration/index-config#indexing-settings
   terminationGracePeriodSeconds: 120
 
+  runtimeClassName: ""
+
   persistentVolume:
     enabled: false
     # storage: "1Gi"
@@ -288,6 +292,8 @@ metastore:
 
   affinity: {}
 
+  runtimeClassName: ""
+
 control_plane:
   # Extra env for control plane
   extraEnv: {}
@@ -348,6 +354,8 @@ control_plane:
   tolerations: []
 
   affinity: {}
+
+  runtimeClassName: ""
 
 janitor:
   # Enable Janitor service
@@ -413,6 +421,8 @@ janitor:
 
   affinity: {}
 
+  runtimeClassName: ""
+
 # Deploy jobs to bootstrap creation of indexes and sources for quickwit clusters
 bootstrap:
   # Enable bootstrap jobs
@@ -440,6 +450,8 @@ bootstrap:
   tolerations: []
 
   affinity: {}
+
+  runtimeClassName: ""
 
   sources:
     # Override command for starting container


### PR DESCRIPTION
This adds the `runtimeClassName` annotation to Deployments, Jobs, and StatefulSets so the containers can run within [GKE Sandbox](https://cloud.google.com/kubernetes-engine/docs/concepts/sandbox-pods) (gVisor). This helps with PCI compliance.

**values.yaml:**

```yaml
searcher:
  runtimeClassName: gvisor

indexer:
  runtimeClassName: gvisor

metastore:
  runtimeClassName: gvisor

control_plane:
  runtimeClassName: gvisor

janitor:
  runtimeClassName: gvisor

bootstrap:
  runtimeClassName: gvisor
```