### PR TITLE
Add pod lifecycle

### DIFF
--- a/charts/quickwit/Chart.yaml
+++ b/charts/quickwit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: quickwit
 description: Sub-second search & analytics engine on cloud storage.
 type: application
-version: 0.7.1
+version: 0.7.2
 appVersion: "v0.8.2"
 keywords:
   - quickwit

--- a/charts/quickwit/templates/indexer-statefulset.yaml
+++ b/charts/quickwit/templates/indexer-statefulset.yaml
@@ -128,6 +128,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.indexer.lifecycle }}
+      lifecycle:
+        {{- toYaml . | nindent 8 }}
+      {{- end}}
   {{- if .Values.indexer.persistentVolume.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/charts/quickwit/templates/indexer-statefulset.yaml
+++ b/charts/quickwit/templates/indexer-statefulset.yaml
@@ -128,7 +128,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.indexer.lifecycle }}
+      {{- with .Values.indexer.lifecycleHooks }}
       lifecycle:
         {{- toYaml . | nindent 8 }}
       {{- end}}

--- a/charts/quickwit/templates/searcher-statefulset.yaml
+++ b/charts/quickwit/templates/searcher-statefulset.yaml
@@ -127,7 +127,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.searcher.lifecycle }}
+      {{- with .Values.searcher.lifecycleHooks }}
       lifecycle:
         {{- toYaml . | nindent 8 }}
       {{- end}}

--- a/charts/quickwit/templates/searcher-statefulset.yaml
+++ b/charts/quickwit/templates/searcher-statefulset.yaml
@@ -127,7 +127,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.indexer.lifecycle }}
+      {{- with .Values.searcher.lifecycle }}
       lifecycle:
         {{- toYaml . | nindent 8 }}
       {{- end}}

--- a/charts/quickwit/templates/searcher-statefulset.yaml
+++ b/charts/quickwit/templates/searcher-statefulset.yaml
@@ -127,6 +127,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.indexer.lifecycle }}
+      lifecycle:
+        {{- toYaml . | nindent 8 }}
+      {{- end}}
   {{- if .Values.searcher.persistentVolume.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -106,6 +106,12 @@ searcher:
       port: rest
 
   lifecycleHooks: {}
+    # preStop:
+    #   exec:
+    #     command:
+    #       - /bin/sh
+    #       - -c
+    #       - sleep 30
 
   # Override args for starting container
   args: []

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -105,6 +105,8 @@ searcher:
       path: /health/readyz
       port: rest
 
+  lifecycleHooks: {}
+
   # Override args for starting container
   args: []
 
@@ -195,6 +197,14 @@ indexer:
   tolerations: []
 
   affinity: {}
+
+  lifecycleHooks: {}
+    # preStop:
+    #   exec:
+    #     command:
+    #       - /bin/sh
+    #       - -c
+    #       - sleep 30
 
   # Long grace period is recommended to wait for all index commit_timeout_secs and splits to be published
   # See https://quickwit.io/docs/configuration/index-config#indexing-settings


### PR DESCRIPTION
Introduced pod lifecycle. When using the AWS Load Balancer Controller, deployments of pods trigger 5xx gateway errors when doing config changes, since the target group registration/deregistration of pods is out of sync with kubernetes service network orchestration (when an indexer pod gets terminated with a SIGTERM, it's done immediately, not giving enough time to drain connections from the ALB's target group, triggering 5xx errors to the client). Introducing a sleep time on indexers can help avoid this during pod termination (as a pre-stop action). 

Related: https://medium.com/@imprintpayments/mastering-the-challenges-of-using-alb-ingress-in-kubernetes-8c28a8f826c5