### PR TITLE
Fix lifecycle container spec

### DIFF
--- a/charts/quickwit/Chart.yaml
+++ b/charts/quickwit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: quickwit
 description: Sub-second search & analytics engine on cloud storage.
 type: application
-version: 0.7.3
+version: 0.7.4
 appVersion: "v0.8.2"
 keywords:
   - quickwit

--- a/charts/quickwit/templates/indexer-statefulset.yaml
+++ b/charts/quickwit/templates/indexer-statefulset.yaml
@@ -96,10 +96,10 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.indexer.resources | nindent 12 }}
-          {{- with .Values.searcher.lifecycleHooks }}
+          {{- if .Values.indexer.lifecycleHooks }}
           lifecycle:
-            {{- toYaml . | nindent 12 }}
-          {{- end}}
+            {{- toYaml .Values.indexer.lifecycleHooks | nindent 12 }}
+          {{- end }}
       terminationGracePeriodSeconds: {{ .Values.indexer.terminationGracePeriodSeconds }}
       volumes:
         - name: config
@@ -132,10 +132,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.indexer.lifecycleHooks }}
-      lifecycle:
-        {{- toYaml . | nindent 8 }}
-      {{- end}}
       {{- if .Values.indexer.runtimeClassName }}
       runtimeClassName: {{ .Values.indexer.runtimeClassName | quote }}
       {{- end }}

--- a/charts/quickwit/templates/indexer-statefulset.yaml
+++ b/charts/quickwit/templates/indexer-statefulset.yaml
@@ -96,6 +96,10 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.indexer.resources | nindent 12 }}
+          {{- with .Values.searcher.lifecycleHooks }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end}}
       terminationGracePeriodSeconds: {{ .Values.indexer.terminationGracePeriodSeconds }}
       volumes:
         - name: config

--- a/charts/quickwit/templates/searcher-statefulset.yaml
+++ b/charts/quickwit/templates/searcher-statefulset.yaml
@@ -96,6 +96,10 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.searcher.resources | nindent 14 }}
+          {{- with .Values.searcher.lifecycleHooks }}
+          lifecycle:
+            {{- toYaml . | nindent 14 }}
+          {{- end}}
       volumes:
         - name: config
           configMap:
@@ -127,10 +131,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.searcher.lifecycleHooks }}
-      lifecycle:
-        {{- toYaml . | nindent 8 }}
-      {{- end}}
       {{- if .Values.searcher.runtimeClassName }}
       runtimeClassName: {{ .Values.searcher.runtimeClassName | quote }}
       {{- end }}

--- a/charts/quickwit/templates/searcher-statefulset.yaml
+++ b/charts/quickwit/templates/searcher-statefulset.yaml
@@ -96,10 +96,10 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.searcher.resources | nindent 14 }}
-          {{- with .Values.searcher.lifecycleHooks }}
+          {{- if .Values.searcher.lifecycleHooks }}
           lifecycle:
-            {{- toYaml . | nindent 14 }}
-          {{- end}}
+            {{- toYaml .Values.searcher.lifecycleHooks | nindent 14 }}
+          {{- end }}
       volumes:
         - name: config
           configMap:


### PR DESCRIPTION
The previous PR https://github.com/quickwit-oss/helm-charts/pull/104 wrongly set lifecyle into spec.template.spec, moving it to spec.template.spec.containers. I've now fully tested with both searchers and indexers, no errors. @guilload sorry for the extra PR and missing this on my previous tests.