### PR TITLE
fixing the indexer.podManagementPolicy

### DIFF
--- a/charts/quickwit/Chart.yaml
+++ b/charts/quickwit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: quickwit
 description: Sub-second search & analytics engine on cloud storage.
 type: application
-version: 0.7.5
+version: 0.7.6
 appVersion: "v0.8.2"
 keywords:
   - quickwit

--- a/charts/quickwit/templates/indexer-statefulset.yaml
+++ b/charts/quickwit/templates/indexer-statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   replicas: {{ .Values.indexer.replicaCount }}
   serviceName: {{ include "quickwit.fullname" . }}-headless
-  {{- if .Values.searcher.podManagementPolicy }}
+  {{- if .Values.indexer.podManagementPolicy }}
   podManagementPolicy: {{ .Values.indexer.podManagementPolicy }}
   {{- end }}
   selector:

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -105,6 +105,11 @@ searcher:
       path: /health/readyz
       port: rest
 
+  # StatefulSet allows you to relax its ordering guarantees
+  #   - OrderedReady
+  #   - Parallel
+  podManagementPolicy: OrderedReady
+
   lifecycleHooks: {}
     # preStop:
     #   exec:
@@ -185,6 +190,11 @@ indexer:
     httpGet:
       path: /health/readyz
       port: rest
+
+  # StatefulSet allows you to relax its ordering guarantees
+  #   - OrderedReady
+  #   - Parallel
+  podManagementPolicy: OrderedReady
 
   # Override args for starting container
   args: []


### PR DESCRIPTION
This fixes the indexer podManagementPolicy. It was set to be enabled if searcher had it enabled

I also added the values as default for OrderedReady which is a kubernetes default into the values file