### PR TITLE
Fix accessing global variables inside range blocks

### DIFF
--- a/charts/quickwit/templates/job-create-indices.yaml
+++ b/charts/quickwit/templates/job-create-indices.yaml
@@ -94,7 +94,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- $tolerations := append .Values.tolerations .Values.bootstrap.tolerations | compact | uniq }}
+      {{- $tolerations := append $.Values.tolerations $.Values.bootstrap.tolerations | compact | uniq }}
       tolerations:
         {{- toYaml $tolerations | nindent 8 }}
       {{- if $.Values.bootstrap.runtimeClassName }}

--- a/charts/quickwit/templates/job-create-sources.yaml
+++ b/charts/quickwit/templates/job-create-sources.yaml
@@ -96,7 +96,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- $tolerations := append .Values.tolerations .Values.bootstrap.tolerations | compact | uniq }}
+      {{- $tolerations := append $.Values.tolerations $.Values.bootstrap.tolerations | compact | uniq }}
       tolerations:
         {{- toYaml $tolerations | nindent 8 }}
       {{- if $.Values.bootstrap.runtimeClassName }}


### PR DESCRIPTION
I replaced .Variables with $.Variables stated in the issue#120

https://github.com/quickwit-oss/helm-charts/issues/120