### PR TITLE
control_plane: added enabled and replicaCount to the config

### DIFF
--- a/charts/quickwit/Chart.yaml
+++ b/charts/quickwit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: quickwit
 description: Sub-second search & analytics engine on cloud storage.
 type: application
-version: 0.8.0
+version: 0.7.11
 appVersion: "v0.8.2"
 keywords:
   - quickwit

--- a/charts/quickwit/Chart.yaml
+++ b/charts/quickwit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: quickwit
 description: Sub-second search & analytics engine on cloud storage.
 type: application
-version: 0.7.10
+version: 0.8.0
 appVersion: "v0.8.2"
 keywords:
   - quickwit

--- a/charts/quickwit/templates/control-plane-deployment.yaml
+++ b/charts/quickwit/templates/control-plane-deployment.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  replicas: {{ .Values.control_plane.replicaCount }}
+  replicas: 1
   selector:
     matchLabels:
       {{- include "quickwit.control_plane.selectorLabels" . | nindent 6 }}

--- a/charts/quickwit/templates/control-plane-deployment.yaml
+++ b/charts/quickwit/templates/control-plane-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.control_plane.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -12,7 +13,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.control_plane.replicaCount }}
   selector:
     matchLabels:
       {{- include "quickwit.control_plane.selectorLabels" . | nindent 6 }}
@@ -123,3 +124,4 @@ spec:
       {{- if .Values.control_plane.runtimeClassName }}
       runtimeClassName: {{ .Values.control_plane.runtimeClassName | quote }}
       {{- end }}
+{{- end }}

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -315,8 +315,6 @@ metastore:
 
 control_plane:
   enabled: true
-
-  replicaCount: 1
   
   # Extra env for control plane
   extraEnv: {}

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -315,7 +315,7 @@ metastore:
 
 control_plane:
   enabled: true
-  
+
   # Extra env for control plane
   extraEnv: {}
     # KEY: VALUE

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -16,7 +16,8 @@ fullnameOverride: ""
 clusterDomain: cluster.local
 
 # -- Additional labels to add to all resources
-additionalLabels: {}
+additionalLabels:
+  {}
   # app: quickwit
 
 serviceAccount:
@@ -40,15 +41,18 @@ securityContext:
   runAsUser: 1005
 
 # Additional global env
-environment: {}
+environment:
+  {}
   # KEY: VALUE
-environmentFrom: []
+environmentFrom:
+  []
   # - secretRef:
   #     name: quickwit
   # - configMapRef:
   #     name: quickwit
 
-configMaps: []
+configMaps:
+  []
   # - name: configmap1
   #   mountPath: /quickwit/configmaps/
 
@@ -62,9 +66,11 @@ searcher:
   replicaCount: 3
 
   # Extra env for searcher
-  extraEnv: {}
+  extraEnv:
+    {}
     # KEY: VALUE
-  extraEnvFrom: []
+  extraEnvFrom:
+    []
     # - secretRef:
     #     name: quickwit-searcher
     # - configMapRef:
@@ -76,7 +82,8 @@ searcher:
   # extraVolumeMounts -- Additional volumes to mount into Quickwit containers.
   extraVolumeMounts: []
 
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
@@ -85,7 +92,8 @@ searcher:
     #   memory: 128Mi
 
   ## Pod distruption budget
-  podDisruptionBudget: {}
+  podDisruptionBudget:
+    {}
     # maxUnavailable: 1
     # minAvailable: 2
 
@@ -94,7 +102,8 @@ searcher:
     # storage: "1Gi"
     # storageClass: ""
 
-  updateStrategy: {}
+  updateStrategy:
+    {}
     # type: RollingUpdate
 
   startupProbe:
@@ -119,7 +128,8 @@ searcher:
   #   - Parallel
   podManagementPolicy: OrderedReady
 
-  lifecycleHooks: {}
+  lifecycleHooks:
+    {}
     # preStop:
     #   exec:
     #     command:
@@ -153,9 +163,11 @@ indexer:
   replicaCount: 1
 
   # Extra env for indexer
-  extraEnv: {}
+  extraEnv:
+    {}
     # KEY: VALUE
-  extraEnvFrom: []
+  extraEnvFrom:
+    []
     # - secretRef:
     #     name: quickwit-indexer
     # - configMapRef:
@@ -167,7 +179,8 @@ indexer:
   # extraVolumeMounts -- Additional volumes to mount into Quickwit containers.
   extraVolumeMounts: []
 
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
@@ -176,11 +189,13 @@ indexer:
     #   memory: 128Mi
 
   ## Pod distruption budget
-  podDisruptionBudget: {}
+  podDisruptionBudget:
+    {}
     # maxUnavailable: 1
     # minAvailable: 2
 
-  updateStrategy: {}
+  updateStrategy:
+    {}
     # type: RollingUpdate
 
   startupProbe:
@@ -225,7 +240,8 @@ indexer:
 
   affinity: {}
 
-  lifecycleHooks: {}
+  lifecycleHooks:
+    {}
     # preStop:
     #   exec:
     #     command:
@@ -248,10 +264,12 @@ metastore:
   replicaCount: 1
 
   # Extra env for metastore
-  extraEnv: {}
+  extraEnv:
+    {}
     # KEY: VALUE
   # This is the recommended way to inject `QW_METASTORE_URI` when using the postgres metastore (see https://quickwit.io/docs/configuration/metastore-config)
-  extraEnvFrom: []
+  extraEnvFrom:
+    []
     # - secretRef:
     #     name: quickwit-metastore
     # - configMapRef:
@@ -263,7 +281,8 @@ metastore:
   # extraVolumeMounts -- Additional volumes to mount into Quickwit containers.
   extraVolumeMounts: []
 
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
@@ -271,7 +290,8 @@ metastore:
     #   cpu: 100m
     #   memory: 128Mi
 
-  updateStrategy: {}
+  updateStrategy:
+    {}
     # type: RollingUpdate
 
   startupProbe:
@@ -314,10 +334,15 @@ metastore:
   runtimeClassName: ""
 
 control_plane:
+  enabled: true
+
+  replicaCount: 1
   # Extra env for control plane
-  extraEnv: {}
+  extraEnv:
+    {}
     # KEY: VALUE
-  extraEnvFrom: []
+  extraEnvFrom:
+    []
     # - secretRef:
     #     name: quickwit-control-plane
     # - configMapRef:
@@ -329,7 +354,8 @@ control_plane:
   # extraVolumeMounts -- Additional volumes to mount into Quickwit containers.
   extraVolumeMounts: []
 
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
@@ -381,9 +407,11 @@ janitor:
   enabled: true
 
   # Extra env for janitor
-  extraEnv: {}
+  extraEnv:
+    {}
     # KEY: VALUE
-  extraEnvFrom: []
+  extraEnvFrom:
+    []
     # - secretRef:
     #     name: quickwit-janitor
     # - configMapRef:
@@ -395,7 +423,8 @@ janitor:
   # extraVolumeMounts -- Additional volumes to mount into Quickwit containers.
   extraVolumeMounts: []
 
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
@@ -448,15 +477,18 @@ bootstrap:
   enabled: false
 
   # Extra env for bootstrap jobs
-  extraEnv: {}
+  extraEnv:
+    {}
     # KEY: VALUE
-  extraEnvFrom: []
+  extraEnvFrom:
+    []
     # - secretRef:
     #     name: quickwit-bootstrap
     # - configMapRef:
     #     name: quickwit-bootstrap
 
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
@@ -512,16 +544,16 @@ config:
   #   max_num_connections: 50
 
   # storage:
-    # s3:
-      # endpoint: "http://custom-s3-endpoint"
-      # region: eu-east-1
-      # We recommend using IAM roles and permissions to access Amazon S3 resources,
-      # but you can specify a pair of access and secret keys if necessary.
-      # access_key_id: <my access key>
-      # secret_access_key: ${AWS_ACCESS_KEY_ID}
-    # azure:
-      # account: "<my account name>"
-      # access_key: ${QW_AZURE_STORAGE_ACCESS_KEY}
+  # s3:
+  # endpoint: "http://custom-s3-endpoint"
+  # region: eu-east-1
+  # We recommend using IAM roles and permissions to access Amazon S3 resources,
+  # but you can specify a pair of access and secret keys if necessary.
+  # access_key_id: <my access key>
+  # secret_access_key: ${AWS_ACCESS_KEY_ID}
+  # azure:
+  # account: "<my account name>"
+  # access_key: ${QW_AZURE_STORAGE_ACCESS_KEY}
 
   # Indexer settings
   # indexer:
@@ -539,7 +571,8 @@ config:
 
 # Seed configuration
 seed:
-  indexes: []
+  indexes:
+    []
     # - version: 0.8
     #   index_id: my-index
     #   doc_mapping:
@@ -562,7 +595,8 @@ seed:
     #       merge_factor: 10
     #       max_merge_factor: 12
 
-  sources: []
+  sources:
+    []
     # - index: my-index
     #   source:
     #     version: 0.8
@@ -632,7 +666,8 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -16,8 +16,7 @@ fullnameOverride: ""
 clusterDomain: cluster.local
 
 # -- Additional labels to add to all resources
-additionalLabels:
-  {}
+additionalLabels: {}
   # app: quickwit
 
 serviceAccount:
@@ -41,18 +40,15 @@ securityContext:
   runAsUser: 1005
 
 # Additional global env
-environment:
-  {}
+environment: {}
   # KEY: VALUE
-environmentFrom:
-  []
+environmentFrom: []
   # - secretRef:
   #     name: quickwit
   # - configMapRef:
   #     name: quickwit
 
-configMaps:
-  []
+configMaps: []
   # - name: configmap1
   #   mountPath: /quickwit/configmaps/
 
@@ -66,11 +62,9 @@ searcher:
   replicaCount: 3
 
   # Extra env for searcher
-  extraEnv:
-    {}
+  extraEnv: {}
     # KEY: VALUE
-  extraEnvFrom:
-    []
+  extraEnvFrom: []
     # - secretRef:
     #     name: quickwit-searcher
     # - configMapRef:
@@ -82,8 +76,7 @@ searcher:
   # extraVolumeMounts -- Additional volumes to mount into Quickwit containers.
   extraVolumeMounts: []
 
-  resources:
-    {}
+  resources: {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
@@ -92,8 +85,7 @@ searcher:
     #   memory: 128Mi
 
   ## Pod distruption budget
-  podDisruptionBudget:
-    {}
+  podDisruptionBudget: {}
     # maxUnavailable: 1
     # minAvailable: 2
 
@@ -102,8 +94,7 @@ searcher:
     # storage: "1Gi"
     # storageClass: ""
 
-  updateStrategy:
-    {}
+  updateStrategy: {}
     # type: RollingUpdate
 
   startupProbe:
@@ -128,8 +119,7 @@ searcher:
   #   - Parallel
   podManagementPolicy: OrderedReady
 
-  lifecycleHooks:
-    {}
+  lifecycleHooks: {}
     # preStop:
     #   exec:
     #     command:
@@ -163,11 +153,9 @@ indexer:
   replicaCount: 1
 
   # Extra env for indexer
-  extraEnv:
-    {}
+  extraEnv: {}
     # KEY: VALUE
-  extraEnvFrom:
-    []
+  extraEnvFrom: []
     # - secretRef:
     #     name: quickwit-indexer
     # - configMapRef:
@@ -179,8 +167,7 @@ indexer:
   # extraVolumeMounts -- Additional volumes to mount into Quickwit containers.
   extraVolumeMounts: []
 
-  resources:
-    {}
+  resources: {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
@@ -189,13 +176,11 @@ indexer:
     #   memory: 128Mi
 
   ## Pod distruption budget
-  podDisruptionBudget:
-    {}
+  podDisruptionBudget: {}
     # maxUnavailable: 1
     # minAvailable: 2
 
-  updateStrategy:
-    {}
+  updateStrategy: {}
     # type: RollingUpdate
 
   startupProbe:
@@ -240,8 +225,7 @@ indexer:
 
   affinity: {}
 
-  lifecycleHooks:
-    {}
+  lifecycleHooks: {}
     # preStop:
     #   exec:
     #     command:
@@ -264,12 +248,10 @@ metastore:
   replicaCount: 1
 
   # Extra env for metastore
-  extraEnv:
-    {}
+  extraEnv: {}
     # KEY: VALUE
   # This is the recommended way to inject `QW_METASTORE_URI` when using the postgres metastore (see https://quickwit.io/docs/configuration/metastore-config)
-  extraEnvFrom:
-    []
+  extraEnvFrom: []
     # - secretRef:
     #     name: quickwit-metastore
     # - configMapRef:
@@ -281,8 +263,7 @@ metastore:
   # extraVolumeMounts -- Additional volumes to mount into Quickwit containers.
   extraVolumeMounts: []
 
-  resources:
-    {}
+  resources: {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
@@ -290,8 +271,7 @@ metastore:
     #   cpu: 100m
     #   memory: 128Mi
 
-  updateStrategy:
-    {}
+  updateStrategy: {}
     # type: RollingUpdate
 
   startupProbe:
@@ -337,12 +317,11 @@ control_plane:
   enabled: true
 
   replicaCount: 1
+  
   # Extra env for control plane
-  extraEnv:
-    {}
+  extraEnv: {}
     # KEY: VALUE
-  extraEnvFrom:
-    []
+  extraEnvFrom: []
     # - secretRef:
     #     name: quickwit-control-plane
     # - configMapRef:
@@ -354,8 +333,7 @@ control_plane:
   # extraVolumeMounts -- Additional volumes to mount into Quickwit containers.
   extraVolumeMounts: []
 
-  resources:
-    {}
+  resources: {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
@@ -407,11 +385,9 @@ janitor:
   enabled: true
 
   # Extra env for janitor
-  extraEnv:
-    {}
+  extraEnv: {}
     # KEY: VALUE
-  extraEnvFrom:
-    []
+  extraEnvFrom: []
     # - secretRef:
     #     name: quickwit-janitor
     # - configMapRef:
@@ -423,8 +399,7 @@ janitor:
   # extraVolumeMounts -- Additional volumes to mount into Quickwit containers.
   extraVolumeMounts: []
 
-  resources:
-    {}
+  resources: {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
@@ -477,18 +452,15 @@ bootstrap:
   enabled: false
 
   # Extra env for bootstrap jobs
-  extraEnv:
-    {}
+  extraEnv: {}
     # KEY: VALUE
-  extraEnvFrom:
-    []
+  extraEnvFrom: []
     # - secretRef:
     #     name: quickwit-bootstrap
     # - configMapRef:
     #     name: quickwit-bootstrap
 
-  resources:
-    {}
+  resources: {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
@@ -544,16 +516,16 @@ config:
   #   max_num_connections: 50
 
   # storage:
-  # s3:
-  # endpoint: "http://custom-s3-endpoint"
-  # region: eu-east-1
-  # We recommend using IAM roles and permissions to access Amazon S3 resources,
-  # but you can specify a pair of access and secret keys if necessary.
-  # access_key_id: <my access key>
-  # secret_access_key: ${AWS_ACCESS_KEY_ID}
-  # azure:
-  # account: "<my account name>"
-  # access_key: ${QW_AZURE_STORAGE_ACCESS_KEY}
+    # s3:
+      # endpoint: "http://custom-s3-endpoint"
+      # region: eu-east-1
+      # We recommend using IAM roles and permissions to access Amazon S3 resources,
+      # but you can specify a pair of access and secret keys if necessary.
+      # access_key_id: <my access key>
+      # secret_access_key: ${AWS_ACCESS_KEY_ID}
+    # azure:
+      # account: "<my account name>"
+      # access_key: ${QW_AZURE_STORAGE_ACCESS_KEY}
 
   # Indexer settings
   # indexer:
@@ -571,8 +543,7 @@ config:
 
 # Seed configuration
 seed:
-  indexes:
-    []
+  indexes: []
     # - version: 0.8
     #   index_id: my-index
     #   doc_mapping:
@@ -595,8 +566,7 @@ seed:
     #       merge_factor: 10
     #       max_merge_factor: 12
 
-  sources:
-    []
+  sources: []
     # - index: my-index
     #   source:
     #     version: 0.8
@@ -666,8 +636,7 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-resources:
-  {}
+resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following


### PR DESCRIPTION
In my use case (and others, too), I have two clusters: one full and another read-only (linked by a shared RDS instance).

I want to disable the control_plane for the read-only cluster because it is not used.

Therefore, I propose to repeat the same pattern as the other components:
- Add a "control_plane.enabled" property with default true
