### PR TITLE
[BUG] replicaCount must accept zero

### DIFF
--- a/charts/quickwit/Chart.yaml
+++ b/charts/quickwit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: quickwit
 description: Sub-second search & analytics engine on cloud storage.
 type: application
-version: 0.7.12
+version: 0.7.13
 appVersion: "v0.8.2"
 keywords:
   - quickwit

--- a/charts/quickwit/templates/indexer-statefulset.yaml
+++ b/charts/quickwit/templates/indexer-statefulset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.indexer.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -12,7 +13,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- if .Values.indexer.replicaCount }}
+  {{- if hasKey .Values.indexer "replicaCount" }}
   replicas: {{ .Values.indexer.replicaCount }}
   {{- end }}
   serviceName: {{ include "quickwit.fullname" . }}-headless
@@ -150,3 +151,4 @@ spec:
         storageClassName: "{{ .Values.indexer.persistentVolume.storageClass }}"
       {{- end }}
   {{- end }}
+{{- end }}

--- a/charts/quickwit/templates/searcher-statefulset.yaml
+++ b/charts/quickwit/templates/searcher-statefulset.yaml
@@ -12,7 +12,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- if .Values.searcher.replicaCount }}
+  {{- if hasKey .Values.searcher "replicaCount" }}
   replicas: {{ .Values.searcher.replicaCount }}
   {{- end }}
   serviceName: {{ include "quickwit.fullname" . }}-headless

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -150,6 +150,8 @@ searcher:
   runtimeClassName: ""
 
 indexer:
+  enabled: true
+
   replicaCount: 1
 
   # Extra env for indexer


### PR DESCRIPTION
In a previous PR (https://github.com/quickwit-oss/helm-charts/pull/124), I added a condition that allows indexer.replicaCount and searcher.replicaCount to be optional (because when you use HPA, the STS replicas field must be omitted).

However, a bug was introduced because the condition `{{- if .Values.indexer.replicaCount }}` will be false when replicaCount is zero.

To improve this, I am also adding the indexer.enabled flag that will help tidy things up. This works better than the `replicaCount: 0` because the indexer statefulset will not be created.

In summary:
1. Fix the replicaCount==0 condition to make it backward compatible with what it used to be.
2. Add the "correct" way, which should be using a new indexer.enabled flag.
