### PR TITLE
Fix #132 : Concat list instead of appending one in the other

### DIFF
--- a/charts/quickwit/Chart.yaml
+++ b/charts/quickwit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: quickwit
 description: Sub-second search & analytics engine on cloud storage.
 type: application
-version: 0.7.15
+version: 0.7.16
 appVersion: v0.8.2
 keywords:
   - quickwit

--- a/charts/quickwit/templates/control-plane-deployment.yaml
+++ b/charts/quickwit/templates/control-plane-deployment.yaml
@@ -118,7 +118,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- $tolerations := append .Values.tolerations .Values.control_plane.tolerations | compact | uniq }}
+      {{- $tolerations := concat .Values.tolerations .Values.control_plane.tolerations | compact | uniq }}
       tolerations:
         {{- toYaml $tolerations | nindent 8 }}
       {{- if .Values.control_plane.runtimeClassName }}

--- a/charts/quickwit/templates/indexer-statefulset.yaml
+++ b/charts/quickwit/templates/indexer-statefulset.yaml
@@ -131,7 +131,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- $tolerations := append .Values.tolerations .Values.indexer.tolerations | compact | uniq }}
+      {{- $tolerations := concat .Values.tolerations .Values.indexer.tolerations | compact | uniq }}
       tolerations:
         {{- toYaml $tolerations | nindent 8 }}
       {{- if .Values.indexer.runtimeClassName }}

--- a/charts/quickwit/templates/janitor-deployment.yaml
+++ b/charts/quickwit/templates/janitor-deployment.yaml
@@ -118,7 +118,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- $tolerations := append .Values.tolerations .Values.janitor.tolerations | compact | uniq }}
+      {{- $tolerations := concat .Values.tolerations .Values.janitor.tolerations | compact | uniq }}
       tolerations:
         {{- toYaml $tolerations | nindent 8 }}
       {{- if .Values.janitor.runtimeClassName }}

--- a/charts/quickwit/templates/job-create-indices.yaml
+++ b/charts/quickwit/templates/job-create-indices.yaml
@@ -94,7 +94,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- $tolerations := append $.Values.tolerations $.Values.bootstrap.tolerations | compact | uniq }}
+      {{- $tolerations := concat $.Values.tolerations $.Values.bootstrap.tolerations | compact | uniq }}
       tolerations:
         {{- toYaml $tolerations | nindent 8 }}
       {{- if $.Values.bootstrap.runtimeClassName }}

--- a/charts/quickwit/templates/job-create-sources.yaml
+++ b/charts/quickwit/templates/job-create-sources.yaml
@@ -96,7 +96,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- $tolerations := append $.Values.tolerations $.Values.bootstrap.tolerations | compact | uniq }}
+      {{- $tolerations := concat $.Values.tolerations $.Values.bootstrap.tolerations | compact | uniq }}
       tolerations:
         {{- toYaml $tolerations | nindent 8 }}
       {{- if $.Values.bootstrap.runtimeClassName }}

--- a/charts/quickwit/templates/metastore-deployment.yaml
+++ b/charts/quickwit/templates/metastore-deployment.yaml
@@ -116,7 +116,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- $tolerations := append .Values.tolerations .Values.metastore.tolerations | compact | uniq }}
+      {{- $tolerations := concat .Values.tolerations .Values.metastore.tolerations | compact | uniq }}
       tolerations:
         {{- toYaml $tolerations | nindent 8 }}
       {{- if .Values.metastore.runtimeClassName }}

--- a/charts/quickwit/templates/searcher-statefulset.yaml
+++ b/charts/quickwit/templates/searcher-statefulset.yaml
@@ -132,7 +132,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- $tolerations := append .Values.tolerations .Values.searcher.tolerations | compact | uniq }}
+      {{- $tolerations := concat .Values.tolerations .Values.searcher.tolerations | compact | uniq }}
       tolerations:
         {{- toYaml $tolerations | nindent 8 }}
       {{- if .Values.searcher.runtimeClassName }}


### PR DESCRIPTION
# Description

To merge the default and specific tolerations for each components, a `append` was used.
As a result, we obtained a list of list.

This PR fix this behavior, using a `concat` to obtain one list with the elements of the others.

Fix #132 