### PR TITLE
support searcher enable flag

### DIFF
--- a/charts/quickwit/Chart.yaml
+++ b/charts/quickwit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: quickwit
 description: Sub-second search & analytics engine on cloud storage.
 type: application
-version: 0.7.16
+version: 0.7.17
 appVersion: v0.8.2
 keywords:
   - quickwit

--- a/charts/quickwit/templates/searcher-statefulset.yaml
+++ b/charts/quickwit/templates/searcher-statefulset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.searcher.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -152,3 +153,4 @@ spec:
         storageClassName: "{{ .Values.searcher.persistentVolume.storageClass }}"
       {{- end }}
   {{- end }}
+{{- end }}

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -59,6 +59,7 @@ tolerations: []
 affinity: {}
 
 searcher:
+  enabled: true
   replicaCount: 3
 
   # Extra env for searcher


### PR DESCRIPTION
## What This PR Does
This PR adds support for an enable flag to the searcher component in the Quickwit Helm chart, mirroring the functionality already in place for the indexer.

## Why We Need This
We have an edge case where we need to consolidate all query load into a single cluster to more effectively leverage split cache behavior.

To support this architecture, we’re splitting the Quickwit components across two clusters:

Cluster 1: Runs indexers + metastore, but no searchers
Cluster 2: Runs searchers + metastore, but no indexers

This setup allows us to separate ingestion and query workloads productively. While ideally we'd unify everything in a single cluster (or namespace), that would currently require more resource allocation and reconfiguration than we can take on right now. 

Adding an enable flag for the searcher allows us to explicitly control whether the chart deploys that component, which is necessary for environments where we only want a subset of services running.