### PR TITLE
add optional pdb for control plane and metastore

### DIFF
--- a/charts/quickwit/Chart.yaml
+++ b/charts/quickwit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: quickwit
 description: Sub-second search & analytics engine on cloud storage.
 type: application
-version: 0.7.17
+version: 0.7.18
 appVersion: v0.8.2
 keywords:
   - quickwit

--- a/charts/quickwit/templates/control-plane-pdb.yaml
+++ b/charts/quickwit/templates/control-plane-pdb.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.control_plane.podDisruptionBudget -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "quickwit.fullname" . }}-control-plane
+  labels:
+    {{- include "quickwit.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "quickwit.control_plane.selectorLabels" . | nindent 6 }}
+  {{- toYaml .Values.control_plane.podDisruptionBudget | nindent 2 }}
+{{- end -}}

--- a/charts/quickwit/templates/metastore-pdb.yaml
+++ b/charts/quickwit/templates/metastore-pdb.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.metastore.podDisruptionBudget -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "quickwit.fullname" . }}-metastore
+  labels:
+    {{- include "quickwit.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "quickwit.metastore.selectorLabels" . | nindent 6 }}
+  {{- toYaml .Values.metastore.podDisruptionBudget | nindent 2 }}
+{{- end -}}

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -274,6 +274,11 @@ metastore:
     #   cpu: 100m
     #   memory: 128Mi
 
+  ## Pod distruption budget
+  podDisruptionBudget: {}
+    # maxUnavailable: 1
+    # minAvailable: 2
+
   updateStrategy: {}
     # type: RollingUpdate
 
@@ -341,6 +346,11 @@ control_plane:
     # requests:
     #   cpu: 100m
     #   memory: 128Mi
+
+  ## Pod distruption budget
+  podDisruptionBudget: {}
+    # maxUnavailable: 1
+    # minAvailable: 2
 
   startupProbe:
     httpGet:


### PR DESCRIPTION
We had a case where the metastore was evicted by Kubectl (because the node was exhausting resources), so we would like to ensure it will not happen again.



I tested running `helm template .` and the PodDisruptionBudget is not generated by default.