### PR TITLE
feat(quickwit): add global topologySpreadConstraints

### DIFF
--- a/charts/quickwit/Chart.yaml
+++ b/charts/quickwit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: quickwit
 description: Sub-second search & analytics engine on cloud storage.
 type: application
-version: 0.8.4
+version: 0.9.0
 appVersion: v0.8.2
 keywords:
   - quickwit

--- a/charts/quickwit/Chart.yaml
+++ b/charts/quickwit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: quickwit
 description: Sub-second search & analytics engine on cloud storage.
 type: application
-version: 0.9.0
+version: 0.8.5
 appVersion: v0.8.2
 keywords:
   - quickwit

--- a/charts/quickwit/templates/_helpers.tpl
+++ b/charts/quickwit/templates/_helpers.tpl
@@ -163,52 +163,6 @@ Quickwit environment
 {{- end }}
 
 {{/*
-Auto-generate a podAntiAffinity rule preventing two pods of the same
-release+service from landing on the same node.
-Called as: include "quickwit.nodeAntiAffinity" (list "indexer" .)
-*/}}
-{{- define "quickwit.nodeAntiAffinity" -}}
-{{- $component := index . 0 -}}
-{{- $ctx := index . 1 -}}
-{{- if $ctx.Values.podAntiAffinity.enabled -}}
-podAntiAffinity:
-  {{- if eq $ctx.Values.podAntiAffinity.preset "soft" }}
-  preferredDuringSchedulingIgnoredDuringExecution:
-    - weight: 100
-      podAffinityTerm:
-        topologyKey: {{ $ctx.Values.podAntiAffinity.topologyKey | quote }}
-        labelSelector:
-          matchLabels:
-            {{- include (printf "quickwit.%s.selectorLabels" $component) $ctx | nindent 12 }}
-  {{- else }}
-  requiredDuringSchedulingIgnoredDuringExecution:
-    - topologyKey: {{ $ctx.Values.podAntiAffinity.topologyKey | quote }}
-      labelSelector:
-        matchLabels:
-          {{- include (printf "quickwit.%s.selectorLabels" $component) $ctx | nindent 10 }}
-  {{- end }}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Resolve the effective affinity for a component.
-Merges global affinity and per-service affinity on top of any auto-generated
-podAntiAffinity rule (same semantics as the existing merge pattern).
-Called as: include "quickwit.componentAffinity" (list "indexer" .)
-*/}}
-{{- define "quickwit.componentAffinity" -}}
-{{- $component := index . 0 -}}
-{{- $ctx := index . 1 -}}
-{{- $explicit := merge (dict) (index $ctx.Values $component).affinity $ctx.Values.affinity -}}
-{{- if $ctx.Values.podAntiAffinity.enabled -}}
-{{- $base := include "quickwit.nodeAntiAffinity" (list $component $ctx) | fromYaml -}}
-{{- toYaml (mergeOverwrite $base $explicit) -}}
-{{- else if $explicit -}}
-{{- toYaml $explicit -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Render extra environment variables supporting both map and list formats.
 Map format (legacy): { KEY: VALUE }
 List format (recommended): [{ name: KEY, value: VALUE, valueFrom: ... }]

--- a/charts/quickwit/templates/_helpers.tpl
+++ b/charts/quickwit/templates/_helpers.tpl
@@ -172,11 +172,21 @@ Called as: include "quickwit.nodeAntiAffinity" (list "indexer" .)
 {{- $ctx := index . 1 -}}
 {{- if $ctx.Values.podAntiAffinity.enabled -}}
 podAntiAffinity:
+  {{- if eq $ctx.Values.podAntiAffinity.preset "soft" }}
+  preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 100
+      podAffinityTerm:
+        topologyKey: {{ $ctx.Values.podAntiAffinity.topologyKey | quote }}
+        labelSelector:
+          matchLabels:
+            {{- include (printf "quickwit.%s.selectorLabels" $component) $ctx | nindent 12 }}
+  {{- else }}
   requiredDuringSchedulingIgnoredDuringExecution:
-    - topologyKey: kubernetes.io/hostname
+    - topologyKey: {{ $ctx.Values.podAntiAffinity.topologyKey | quote }}
       labelSelector:
         matchLabels:
           {{- include (printf "quickwit.%s.selectorLabels" $component) $ctx | nindent 10 }}
+  {{- end }}
 {{- end -}}
 {{- end -}}
 
@@ -195,26 +205,6 @@ Called as: include "quickwit.componentAffinity" (list "indexer" .)
 {{- toYaml (mergeOverwrite $base $explicit) -}}
 {{- else if $explicit -}}
 {{- toYaml $explicit -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Auto-generate a topologySpreadConstraints entry to spread pods across zones.
-Per-service Values.<component>.zoneSpreadConstraint takes precedence over
-the global Values.zoneSpreadConstraint.
-Called as: include "quickwit.zoneSpreadConstraint" (list "indexer" .)
-*/}}
-{{- define "quickwit.zoneSpreadConstraint" -}}
-{{- $component := index . 0 -}}
-{{- $ctx := index . 1 -}}
-{{- $zsc := (index $ctx.Values $component).zoneSpreadConstraint | default $ctx.Values.zoneSpreadConstraint -}}
-{{- if $zsc.enabled -}}
-maxSkew: {{ $zsc.maxSkew | default 1 }}
-topologyKey: {{ $zsc.topologyKey | default "topology.kubernetes.io/zone" | quote }}
-whenUnsatisfiable: {{ $zsc.whenUnsatisfiable | default "DoNotSchedule" | quote }}
-labelSelector:
-  matchLabels:
-    {{- include (printf "quickwit.%s.selectorLabels" $component) $ctx | nindent 4 }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/quickwit/templates/_helpers.tpl
+++ b/charts/quickwit/templates/_helpers.tpl
@@ -163,6 +163,62 @@ Quickwit environment
 {{- end }}
 
 {{/*
+Auto-generate a podAntiAffinity rule preventing two pods of the same
+release+service from landing on the same node.
+Called as: include "quickwit.nodeAntiAffinity" (list "indexer" .)
+*/}}
+{{- define "quickwit.nodeAntiAffinity" -}}
+{{- $component := index . 0 -}}
+{{- $ctx := index . 1 -}}
+{{- if $ctx.Values.podAntiAffinity.enabled -}}
+podAntiAffinity:
+  requiredDuringSchedulingIgnoredDuringExecution:
+    - topologyKey: kubernetes.io/hostname
+      labelSelector:
+        matchLabels:
+          {{- include (printf "quickwit.%s.selectorLabels" $component) $ctx | nindent 10 }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Resolve the effective affinity for a component.
+Merges global affinity and per-service affinity on top of any auto-generated
+podAntiAffinity rule (same semantics as the existing merge pattern).
+Called as: include "quickwit.componentAffinity" (list "indexer" .)
+*/}}
+{{- define "quickwit.componentAffinity" -}}
+{{- $component := index . 0 -}}
+{{- $ctx := index . 1 -}}
+{{- $explicit := merge (dict) (index $ctx.Values $component).affinity $ctx.Values.affinity -}}
+{{- if $ctx.Values.podAntiAffinity.enabled -}}
+{{- $base := include "quickwit.nodeAntiAffinity" (list $component $ctx) | fromYaml -}}
+{{- toYaml (mergeOverwrite $base $explicit) -}}
+{{- else if $explicit -}}
+{{- toYaml $explicit -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Auto-generate a topologySpreadConstraints entry to spread pods across zones.
+Per-service Values.<component>.zoneSpreadConstraint takes precedence over
+the global Values.zoneSpreadConstraint.
+Called as: include "quickwit.zoneSpreadConstraint" (list "indexer" .)
+*/}}
+{{- define "quickwit.zoneSpreadConstraint" -}}
+{{- $component := index . 0 -}}
+{{- $ctx := index . 1 -}}
+{{- $zsc := (index $ctx.Values $component).zoneSpreadConstraint | default $ctx.Values.zoneSpreadConstraint -}}
+{{- if $zsc.enabled -}}
+maxSkew: {{ $zsc.maxSkew | default 1 }}
+topologyKey: {{ $zsc.topologyKey | default "topology.kubernetes.io/zone" | quote }}
+whenUnsatisfiable: {{ $zsc.whenUnsatisfiable | default "DoNotSchedule" | quote }}
+labelSelector:
+  matchLabels:
+    {{- include (printf "quickwit.%s.selectorLabels" $component) $ctx | nindent 4 }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Render extra environment variables supporting both map and list formats.
 Map format (legacy): { KEY: VALUE }
 List format (recommended): [{ name: KEY, value: VALUE, valueFrom: ... }]

--- a/charts/quickwit/templates/control-plane-deployment.yaml
+++ b/charts/quickwit/templates/control-plane-deployment.yaml
@@ -124,9 +124,7 @@ spec:
       {{- if .Values.control_plane.runtimeClassName }}
       runtimeClassName: {{ .Values.control_plane.runtimeClassName | quote }}
       {{- end }}
-      {{- $zscEntry := include "quickwit.zoneSpreadConstraint" (list "control_plane" .) | fromYaml }}
       {{- $tsc := concat .Values.topologySpreadConstraints .Values.control_plane.topologySpreadConstraints | compact }}
-      {{- if $zscEntry }}{{- $tsc = append $tsc $zscEntry }}{{- end }}
       {{- if $tsc }}
       topologySpreadConstraints:
         {{- toYaml $tsc | nindent 8 }}

--- a/charts/quickwit/templates/control-plane-deployment.yaml
+++ b/charts/quickwit/templates/control-plane-deployment.yaml
@@ -113,9 +113,10 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with merge (dict) .Values.control_plane.affinity .Values.affinity }}
+      {{- $affinity := include "quickwit.componentAffinity" (list "control_plane" .) }}
+      {{- with $affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
       {{- $tolerations := concat .Values.tolerations .Values.control_plane.tolerations | compact | uniq }}
       tolerations:
@@ -123,8 +124,11 @@ spec:
       {{- if .Values.control_plane.runtimeClassName }}
       runtimeClassName: {{ .Values.control_plane.runtimeClassName | quote }}
       {{- end }}
-      {{- with .Values.control_plane.topologySpreadConstraints }}
+      {{- $zscEntry := include "quickwit.zoneSpreadConstraint" (list "control_plane" .) | fromYaml }}
+      {{- $tsc := concat .Values.topologySpreadConstraints .Values.control_plane.topologySpreadConstraints | compact }}
+      {{- if $zscEntry }}{{- $tsc = append $tsc $zscEntry }}{{- end }}
+      {{- if $tsc }}
       topologySpreadConstraints:
-        {{- toYaml . | nindent 8 }}
-      {{ end }}
+        {{- toYaml $tsc | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/quickwit/templates/control-plane-deployment.yaml
+++ b/charts/quickwit/templates/control-plane-deployment.yaml
@@ -113,10 +113,9 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- $affinity := include "quickwit.componentAffinity" (list "control_plane" .) }}
-      {{- with $affinity }}
+      {{- with merge (dict) .Values.control_plane.affinity .Values.affinity }}
       affinity:
-        {{- . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- $tolerations := concat .Values.tolerations .Values.control_plane.tolerations | compact | uniq }}
       tolerations:

--- a/charts/quickwit/templates/indexer-statefulset.yaml
+++ b/charts/quickwit/templates/indexer-statefulset.yaml
@@ -126,10 +126,9 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- $affinity := include "quickwit.componentAffinity" (list "indexer" .) }}
-      {{- with $affinity }}
+      {{- with merge (dict) .Values.indexer.affinity .Values.affinity }}
       affinity:
-        {{- . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- $tolerations := concat .Values.tolerations .Values.indexer.tolerations | compact | uniq }}
       tolerations:

--- a/charts/quickwit/templates/indexer-statefulset.yaml
+++ b/charts/quickwit/templates/indexer-statefulset.yaml
@@ -126,9 +126,10 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with merge (dict) .Values.indexer.affinity .Values.affinity }}
+      {{- $affinity := include "quickwit.componentAffinity" (list "indexer" .) }}
+      {{- with $affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
       {{- $tolerations := concat .Values.tolerations .Values.indexer.tolerations | compact | uniq }}
       tolerations:
@@ -136,10 +137,13 @@ spec:
       {{- if .Values.indexer.runtimeClassName }}
       runtimeClassName: {{ .Values.indexer.runtimeClassName | quote }}
       {{- end }}
-      {{- with .Values.indexer.topologySpreadConstraints }}
+      {{- $zscEntry := include "quickwit.zoneSpreadConstraint" (list "indexer" .) | fromYaml }}
+      {{- $tsc := concat .Values.topologySpreadConstraints .Values.indexer.topologySpreadConstraints | compact }}
+      {{- if $zscEntry }}{{- $tsc = append $tsc $zscEntry }}{{- end }}
+      {{- if $tsc }}
       topologySpreadConstraints:
-        {{- toYaml . | nindent 8 }}
-      {{ end }}
+        {{- toYaml $tsc | nindent 8 }}
+      {{- end }}
   {{- if .Values.indexer.persistentVolume.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/charts/quickwit/templates/indexer-statefulset.yaml
+++ b/charts/quickwit/templates/indexer-statefulset.yaml
@@ -137,9 +137,7 @@ spec:
       {{- if .Values.indexer.runtimeClassName }}
       runtimeClassName: {{ .Values.indexer.runtimeClassName | quote }}
       {{- end }}
-      {{- $zscEntry := include "quickwit.zoneSpreadConstraint" (list "indexer" .) | fromYaml }}
       {{- $tsc := concat .Values.topologySpreadConstraints .Values.indexer.topologySpreadConstraints | compact }}
-      {{- if $zscEntry }}{{- $tsc = append $tsc $zscEntry }}{{- end }}
       {{- if $tsc }}
       topologySpreadConstraints:
         {{- toYaml $tsc | nindent 8 }}

--- a/charts/quickwit/templates/janitor-deployment.yaml
+++ b/charts/quickwit/templates/janitor-deployment.yaml
@@ -124,9 +124,7 @@ spec:
       {{- if .Values.janitor.runtimeClassName }}
       runtimeClassName: {{ .Values.janitor.runtimeClassName | quote }}
       {{- end }}
-      {{- $zscEntry := include "quickwit.zoneSpreadConstraint" (list "janitor" .) | fromYaml }}
       {{- $tsc := concat .Values.topologySpreadConstraints .Values.janitor.topologySpreadConstraints | compact }}
-      {{- if $zscEntry }}{{- $tsc = append $tsc $zscEntry }}{{- end }}
       {{- if $tsc }}
       topologySpreadConstraints:
         {{- toYaml $tsc | nindent 8 }}

--- a/charts/quickwit/templates/janitor-deployment.yaml
+++ b/charts/quickwit/templates/janitor-deployment.yaml
@@ -113,10 +113,9 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- $affinity := include "quickwit.componentAffinity" (list "janitor" .) }}
-      {{- with $affinity }}
+      {{- with merge (dict) .Values.janitor.affinity .Values.affinity }}
       affinity:
-        {{- . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- $tolerations := concat .Values.tolerations .Values.janitor.tolerations | compact | uniq }}
       tolerations:

--- a/charts/quickwit/templates/janitor-deployment.yaml
+++ b/charts/quickwit/templates/janitor-deployment.yaml
@@ -113,9 +113,10 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with merge (dict) .Values.janitor.affinity .Values.affinity }}
+      {{- $affinity := include "quickwit.componentAffinity" (list "janitor" .) }}
+      {{- with $affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
       {{- $tolerations := concat .Values.tolerations .Values.janitor.tolerations | compact | uniq }}
       tolerations:
@@ -123,8 +124,11 @@ spec:
       {{- if .Values.janitor.runtimeClassName }}
       runtimeClassName: {{ .Values.janitor.runtimeClassName | quote }}
       {{- end }}
-      {{- with .Values.janitor.topologySpreadConstraints }}
+      {{- $zscEntry := include "quickwit.zoneSpreadConstraint" (list "janitor" .) | fromYaml }}
+      {{- $tsc := concat .Values.topologySpreadConstraints .Values.janitor.topologySpreadConstraints | compact }}
+      {{- if $zscEntry }}{{- $tsc = append $tsc $zscEntry }}{{- end }}
+      {{- if $tsc }}
       topologySpreadConstraints:
-        {{- toYaml . | nindent 8 }}
-      {{ end }}
+        {{- toYaml $tsc | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/quickwit/templates/metastore-deployment.yaml
+++ b/charts/quickwit/templates/metastore-deployment.yaml
@@ -122,9 +122,7 @@ spec:
       {{- if .Values.metastore.runtimeClassName }}
       runtimeClassName: {{ .Values.metastore.runtimeClassName | quote }}
       {{- end }}
-      {{- $zscEntry := include "quickwit.zoneSpreadConstraint" (list "metastore" .) | fromYaml }}
       {{- $tsc := concat .Values.topologySpreadConstraints .Values.metastore.topologySpreadConstraints | compact }}
-      {{- if $zscEntry }}{{- $tsc = append $tsc $zscEntry }}{{- end }}
       {{- if $tsc }}
       topologySpreadConstraints:
         {{- toYaml $tsc | nindent 8 }}

--- a/charts/quickwit/templates/metastore-deployment.yaml
+++ b/charts/quickwit/templates/metastore-deployment.yaml
@@ -111,10 +111,9 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- $affinity := include "quickwit.componentAffinity" (list "metastore" .) }}
-      {{- with $affinity }}
+      {{- with merge (dict) .Values.metastore.affinity .Values.affinity }}
       affinity:
-        {{- . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- $tolerations := concat .Values.tolerations .Values.metastore.tolerations | compact | uniq }}
       tolerations:

--- a/charts/quickwit/templates/metastore-deployment.yaml
+++ b/charts/quickwit/templates/metastore-deployment.yaml
@@ -111,9 +111,10 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with merge (dict) .Values.metastore.affinity .Values.affinity }}
+      {{- $affinity := include "quickwit.componentAffinity" (list "metastore" .) }}
+      {{- with $affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
       {{- $tolerations := concat .Values.tolerations .Values.metastore.tolerations | compact | uniq }}
       tolerations:
@@ -121,7 +122,10 @@ spec:
       {{- if .Values.metastore.runtimeClassName }}
       runtimeClassName: {{ .Values.metastore.runtimeClassName | quote }}
       {{- end }}
-      {{- with .Values.metastore.topologySpreadConstraints }}
+      {{- $zscEntry := include "quickwit.zoneSpreadConstraint" (list "metastore" .) | fromYaml }}
+      {{- $tsc := concat .Values.topologySpreadConstraints .Values.metastore.topologySpreadConstraints | compact }}
+      {{- if $zscEntry }}{{- $tsc = append $tsc $zscEntry }}{{- end }}
+      {{- if $tsc }}
       topologySpreadConstraints:
-        {{- toYaml . | nindent 8 }}
-      {{ end }}
+        {{- toYaml $tsc | nindent 8 }}
+      {{- end }}

--- a/charts/quickwit/templates/searcher-statefulset.yaml
+++ b/charts/quickwit/templates/searcher-statefulset.yaml
@@ -128,10 +128,9 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- $affinity := include "quickwit.componentAffinity" (list "searcher" .) }}
-      {{- with $affinity }}
+      {{- with merge (dict) .Values.searcher.affinity .Values.affinity }}
       affinity:
-        {{- . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- $tolerations := concat .Values.tolerations .Values.searcher.tolerations | compact | uniq }}
       tolerations:

--- a/charts/quickwit/templates/searcher-statefulset.yaml
+++ b/charts/quickwit/templates/searcher-statefulset.yaml
@@ -139,9 +139,7 @@ spec:
       {{- if .Values.searcher.runtimeClassName }}
       runtimeClassName: {{ .Values.searcher.runtimeClassName | quote }}
       {{- end }}
-      {{- $zscEntry := include "quickwit.zoneSpreadConstraint" (list "searcher" .) | fromYaml }}
       {{- $tsc := concat .Values.topologySpreadConstraints .Values.searcher.topologySpreadConstraints | compact }}
-      {{- if $zscEntry }}{{- $tsc = append $tsc $zscEntry }}{{- end }}
       {{- if $tsc }}
       topologySpreadConstraints:
         {{- toYaml $tsc | nindent 8 }}

--- a/charts/quickwit/templates/searcher-statefulset.yaml
+++ b/charts/quickwit/templates/searcher-statefulset.yaml
@@ -128,9 +128,10 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with merge (dict) .Values.searcher.affinity .Values.affinity }}
+      {{- $affinity := include "quickwit.componentAffinity" (list "searcher" .) }}
+      {{- with $affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
       {{- $tolerations := concat .Values.tolerations .Values.searcher.tolerations | compact | uniq }}
       tolerations:
@@ -138,10 +139,13 @@ spec:
       {{- if .Values.searcher.runtimeClassName }}
       runtimeClassName: {{ .Values.searcher.runtimeClassName | quote }}
       {{- end }}
-      {{- with .Values.searcher.topologySpreadConstraints }}
+      {{- $zscEntry := include "quickwit.zoneSpreadConstraint" (list "searcher" .) | fromYaml }}
+      {{- $tsc := concat .Values.topologySpreadConstraints .Values.searcher.topologySpreadConstraints | compact }}
+      {{- if $zscEntry }}{{- $tsc = append $tsc $zscEntry }}{{- end }}
+      {{- if $tsc }}
       topologySpreadConstraints:
-        {{- toYaml . | nindent 8 }}
-      {{ end }}
+        {{- toYaml $tsc | nindent 8 }}
+      {{- end }}
   {{- if .Values.searcher.persistentVolume.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -65,17 +65,15 @@ tolerations: []
 # Global affinity settings applied to all deployments
 affinity: {}
 
-# Auto-generate per-service podAntiAffinity (one pod per node per release+service).
+# -- Auto-generate per-service podAntiAffinity (one pod per node per release+service).
 podAntiAffinity:
+  # -- Enable podAntiAffinity rule.
   enabled: false
-
-# Auto-generate a topologySpreadConstraints entry to spread pods across zones per service.
-# Per-service values (e.g. indexer.zoneSpreadConstraint) override this global config.
-zoneSpreadConstraint:
-  enabled: false
-  topologyKey: topology.kubernetes.io/zone
-  whenUnsatisfiable: DoNotSchedule
-  maxSkew: 1
+  # -- Scheduling strictness. "hard" uses requiredDuringSchedulingIgnoredDuringExecution;
+  # "soft" uses preferredDuringSchedulingIgnoredDuringExecution (weight: 100).
+  preset: hard
+  # -- Topology key used for the anti-affinity rule.
+  topologyKey: kubernetes.io/hostname
 
 # topologySpreadConstraints -- Configure
 # [topology spread constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/).
@@ -180,8 +178,6 @@ searcher:
 
   topologySpreadConstraints: []
 
-  # searcher.zoneSpreadConstraint -- Overrides the global `zoneSpreadConstraint` for the searcher pods only.
-  zoneSpreadConstraint: {}
 
 indexer:
   enabled: true
@@ -287,8 +283,6 @@ indexer:
 
   topologySpreadConstraints: []
 
-  # indexer.zoneSpreadConstraint -- Overrides the global `zoneSpreadConstraint` for the indexer pods only.
-  zoneSpreadConstraint: {}
 
 metastore:
   replicaCount: 1
@@ -370,8 +364,6 @@ metastore:
 
   topologySpreadConstraints: []
 
-  # metastore.zoneSpreadConstraint -- Overrides the global `zoneSpreadConstraint` for the metastore pods only.
-  zoneSpreadConstraint: {}
 
 control_plane:
   enabled: true
@@ -449,8 +441,6 @@ control_plane:
 
   topologySpreadConstraints: []
 
-  # control_plane.zoneSpreadConstraint -- Overrides the global `zoneSpreadConstraint` for the control-plane pods only.
-  zoneSpreadConstraint: {}
 
 janitor:
   # Enable Janitor service
@@ -524,8 +514,6 @@ janitor:
 
   topologySpreadConstraints: []
 
-  # janitor.zoneSpreadConstraint -- Overrides the global `zoneSpreadConstraint` for the janitor pods only.
-  zoneSpreadConstraint: {}
 
 # Deploy jobs to bootstrap creation of indexes and sources for quickwit clusters
 bootstrap:

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -65,6 +65,22 @@ tolerations: []
 # Global affinity settings applied to all deployments
 affinity: {}
 
+# Auto-generate per-service podAntiAffinity (one pod per node per release+service).
+podAntiAffinity:
+  enabled: false
+
+# Auto-generate a topologySpreadConstraints entry to spread pods across zones per service.
+# Per-service values (e.g. indexer.zoneSpreadConstraint) override this global config.
+zoneSpreadConstraint:
+  enabled: false
+  topologyKey: topology.kubernetes.io/zone
+  whenUnsatisfiable: DoNotSchedule
+  maxSkew: 1
+
+# topologySpreadConstraints -- Configure
+# [topology spread constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/).
+topologySpreadConstraints: []
+
 searcher:
   enabled: true
   replicaCount: 3
@@ -163,6 +179,9 @@ searcher:
   runtimeClassName: ""
 
   topologySpreadConstraints: []
+
+  # searcher.zoneSpreadConstraint -- Overrides the global `zoneSpreadConstraint` for the searcher pods only.
+  zoneSpreadConstraint: {}
 
 indexer:
   enabled: true
@@ -268,6 +287,9 @@ indexer:
 
   topologySpreadConstraints: []
 
+  # indexer.zoneSpreadConstraint -- Overrides the global `zoneSpreadConstraint` for the indexer pods only.
+  zoneSpreadConstraint: {}
+
 metastore:
   replicaCount: 1
 
@@ -348,6 +370,9 @@ metastore:
 
   topologySpreadConstraints: []
 
+  # metastore.zoneSpreadConstraint -- Overrides the global `zoneSpreadConstraint` for the metastore pods only.
+  zoneSpreadConstraint: {}
+
 control_plane:
   enabled: true
 
@@ -424,6 +449,9 @@ control_plane:
 
   topologySpreadConstraints: []
 
+  # control_plane.zoneSpreadConstraint -- Overrides the global `zoneSpreadConstraint` for the control-plane pods only.
+  zoneSpreadConstraint: {}
+
 janitor:
   # Enable Janitor service
   enabled: true
@@ -495,6 +523,9 @@ janitor:
   runtimeClassName: ""
 
   topologySpreadConstraints: []
+
+  # janitor.zoneSpreadConstraint -- Overrides the global `zoneSpreadConstraint` for the janitor pods only.
+  zoneSpreadConstraint: {}
 
 # Deploy jobs to bootstrap creation of indexes and sources for quickwit clusters
 bootstrap:

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -59,24 +59,13 @@ configMaps: []
   # - name: configmap1
   #   mountPath: /quickwit/configmaps/
 
-# Global tolerations applied to all deployments
+# -- Global tolerations applied to all deployments.
 tolerations: []
 
-# Global affinity settings applied to all deployments
+# -- Global affinity settings applied to all deployments.
 affinity: {}
 
-# -- Auto-generate per-service podAntiAffinity (one pod per node per release+service).
-podAntiAffinity:
-  # -- Enable podAntiAffinity rule.
-  enabled: false
-  # -- Scheduling strictness. "hard" uses requiredDuringSchedulingIgnoredDuringExecution;
-  # "soft" uses preferredDuringSchedulingIgnoredDuringExecution (weight: 100).
-  preset: hard
-  # -- Topology key used for the anti-affinity rule.
-  topologyKey: kubernetes.io/hostname
-
-# topologySpreadConstraints -- Configure
-# [topology spread constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/).
+# -- Configure [topology spread constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/).
 topologySpreadConstraints: []
 
 searcher:
@@ -177,7 +166,6 @@ searcher:
   runtimeClassName: ""
 
   topologySpreadConstraints: []
-
 
 indexer:
   enabled: true
@@ -283,7 +271,6 @@ indexer:
 
   topologySpreadConstraints: []
 
-
 metastore:
   replicaCount: 1
 
@@ -364,7 +351,6 @@ metastore:
 
   topologySpreadConstraints: []
 
-
 control_plane:
   enabled: true
 
@@ -441,7 +427,6 @@ control_plane:
 
   topologySpreadConstraints: []
 
-
 janitor:
   # Enable Janitor service
   enabled: true
@@ -513,7 +498,6 @@ janitor:
   runtimeClassName: ""
 
   topologySpreadConstraints: []
-
 
 # Deploy jobs to bootstrap creation of indexes and sources for quickwit clusters
 bootstrap:


### PR DESCRIPTION
## Summary

- **`topologySpreadConstraints` (global + per-service)** — a global `topologySpreadConstraints` value is now available alongside the existing per-service ones. Global and per-service entries are concatenated (additive, like `tolerations`).

## Motivation

When running on EKS with Karpenter (or any node autoprovisioner), pods of the same service can be co-located on the same node or in the same availability zone. The standard fix — hardcoding release name and component labels in `affinity` or `topologySpreadConstraints` — is not possible directly in `values.yaml` because `$.Release.Name` is only available in templates.

Kubernetes 1.27+ solves this with [`matchLabelKeys`](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) in `topologySpreadConstraints`: the scheduler dynamically resolves label values (including the release name) from the incoming pod at scheduling time, without any hardcoding.

## Recommended config

```yaml
affinity:
  podAntiAffinity:
    requiredDuringSchedulingIgnoredDuringExecution:
    - topologyKey: kubernetes.io/hostname
      labelSelector: {}
      matchLabelKeys:
        - app.kubernetes.io/name
        - app.kubernetes.io/instance
        - app.kubernetes.io/component

topologySpreadConstraints:
  - maxSkew: 1
    topologyKey: topology.kubernetes.io/zone
    whenUnsatisfiable: DoNotSchedule
    labelSelector: {}
    matchLabelKeys:
      - app.kubernetes.io/name
      - app.kubernetes.io/instance
      - app.kubernetes.io/component
```