### PR TITLE
Add dedicated health port to Quickwit chart

### DIFF
--- a/charts/quickwit/Chart.yaml
+++ b/charts/quickwit/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: quickwit
 description: Sub-second search & analytics engine on cloud storage.
 type: application
-version: 0.8.6
-appVersion: v0.8.2
+version: 0.8.7
+appVersion: v0.8.3
 keywords:
   - quickwit
   - search

--- a/charts/quickwit/Chart.yaml
+++ b/charts/quickwit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: quickwit
 description: Sub-second search & analytics engine on cloud storage.
 type: application
-version: 0.8.5
+version: 0.8.6
 appVersion: v0.8.2
 keywords:
   - quickwit

--- a/charts/quickwit/templates/_helpers.tpl
+++ b/charts/quickwit/templates/_helpers.tpl
@@ -111,9 +111,6 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
-{{/*
-Quickwit ports
-*/}}
 {{- define "quickwit.ports" -}}
 - name: rest
   containerPort: 7280
@@ -124,6 +121,9 @@ Quickwit ports
 - name: discovery
   containerPort: 7282
   protocol: UDP
+- name: health
+  containerPort: 7283
+  protocol: TCP
 {{- end }}
 
 

--- a/charts/quickwit/templates/service.yaml
+++ b/charts/quickwit/templates/service.yaml
@@ -36,6 +36,10 @@ spec:
       {{- if and (eq $type "NodePort") .Values.searcher.grpcNodePort }}
       nodePort: {{ .Values.searcher.grpcNodePort }}
       {{- end }}
+    - port: 7283
+      targetPort: health
+      protocol: TCP
+      name: health
   selector:
     {{- include "quickwit.searcher.selectorLabels" . | nindent 4 }}
 {{- end }}
@@ -114,6 +118,10 @@ spec:
       {{- if and (eq $type "NodePort") .Values.indexer.grpcNodePort }}
       nodePort: {{ .Values.indexer.grpcNodePort }}
       {{- end }}
+    - port: 7283
+      targetPort: health
+      protocol: TCP
+      name: health
   selector:
     {{- include "quickwit.indexer.selectorLabels" . | nindent 4 }}
 {{- end }}
@@ -155,6 +163,10 @@ spec:
       {{- if and (eq $type "NodePort") .Values.metastore.grpcNodePort }}
       nodePort: {{ .Values.metastore.grpcNodePort }}
       {{- end }}
+    - port: 7283
+      targetPort: health
+      protocol: TCP
+      name: health
   selector:
     {{- include "quickwit.metastore.selectorLabels" . | nindent 4 }}
 ---
@@ -196,6 +208,10 @@ spec:
       {{- if and (eq $type "NodePort") .Values.control_plane.grpcNodePort }}
       nodePort: {{ .Values.control_plane.grpcNodePort }}
       {{- end }}
+    - port: 7283
+      targetPort: health
+      protocol: TCP
+      name: health
   selector:
     {{- include "quickwit.control_plane.selectorLabels" . | nindent 4 }}
 {{- end }}
@@ -238,6 +254,10 @@ spec:
       {{- if and (eq $type "NodePort") .Values.janitor.grpcNodePort }}
       nodePort: {{ .Values.janitor.grpcNodePort }}
       {{- end }}
+    - port: 7283
+      targetPort: health
+      protocol: TCP
+      name: health
   selector:
     {{- include "quickwit.janitor.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -114,19 +114,19 @@ searcher:
   startupProbe:
     httpGet:
       path: /health/livez
-      port: rest
+      port: health
     failureThreshold: 12
     periodSeconds: 5
 
   livenessProbe:
     httpGet:
       path: /health/livez
-      port: rest
+      port: health
 
   readinessProbe:
     httpGet:
       path: /health/readyz
-      port: rest
+      port: health
 
   # StatefulSet allows you to relax its ordering guarantees
   #   - OrderedReady
@@ -208,19 +208,19 @@ indexer:
   startupProbe:
     httpGet:
       path: /health/livez
-      port: rest
+      port: health
     failureThreshold: 12
     periodSeconds: 5
 
   livenessProbe:
     httpGet:
       path: /health/livez
-      port: rest
+      port: health
 
   readinessProbe:
     httpGet:
       path: /health/readyz
-      port: rest
+      port: health
 
   # StatefulSet allows you to relax its ordering guarantees
   #   - OrderedReady
@@ -311,19 +311,19 @@ metastore:
   startupProbe:
     httpGet:
       path: /health/livez
-      port: rest
+      port: health
     failureThreshold: 12
     periodSeconds: 5
 
   livenessProbe:
     httpGet:
       path: /health/livez
-      port: rest
+      port: health
 
   readinessProbe:
     httpGet:
       path: /health/readyz
-      port: rest
+      port: health
 
   # Override args for starting container
   args: []
@@ -387,19 +387,19 @@ control_plane:
   startupProbe:
     httpGet:
       path: /health/livez
-      port: rest
+      port: health
     failureThreshold: 12
     periodSeconds: 5
 
   livenessProbe:
     httpGet:
       path: /health/livez
-      port: rest
+      port: health
 
   readinessProbe:
     httpGet:
       path: /health/readyz
-      port: rest
+      port: health
 
   # Override args for starting container
   args: []
@@ -459,19 +459,19 @@ janitor:
   startupProbe:
     httpGet:
       path: /health/livez
-      port: rest
+      port: health
     failureThreshold: 12
     periodSeconds: 5
 
   livenessProbe:
     httpGet:
       path: /health/livez
-      port: rest
+      port: health
 
   readinessProbe:
     httpGet:
       path: /health/readyz
-      port: rest
+      port: health
 
   # Override args for starting container
   args: []
@@ -569,6 +569,9 @@ config:
   # cluster_id: my-cluster
   listen_address: 0.0.0.0
   gossip_listen_port: 7282
+  health:
+    # Dedicated plaintext health check server used by health checks.
+    listen_port: 7283
   data_dir: /quickwit/qwdata
   default_index_root_uri: s3://quickwit/indexes
 


### PR DESCRIPTION
## Summary
In response to https://github.com/quickwit-oss/quickwit/pull/6528, we enabled the HTTP health check service by default and use it for the health check. Note we have to release Quickwit v0.8.3 (or could be v0.9.0) before merging this PR.

