### PR TITLE
Add standalone compactors flag and service charts

### DIFF
--- a/charts/quickwit/Chart.yaml
+++ b/charts/quickwit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: quickwit
 description: Sub-second search & analytics engine on cloud storage.
 type: application
-version: 0.8.7
+version: 0.8.8
 appVersion: v0.8.2
 keywords:
   - quickwit

--- a/charts/quickwit/templates/_helpers.tpl
+++ b/charts/quickwit/templates/_helpers.tpl
@@ -127,6 +127,7 @@ storage.k8s.io/v1beta1
 {{- end -}}
 {{- end }}
 
+{{/*
 Compactor Selector labels
 */}}
 {{- define "quickwit.compactor.selectorLabels" -}}

--- a/charts/quickwit/templates/_helpers.tpl
+++ b/charts/quickwit/templates/_helpers.tpl
@@ -127,6 +127,13 @@ storage.k8s.io/v1beta1
 {{- end -}}
 {{- end }}
 
+Compactor Selector labels
+*/}}
+{{- define "quickwit.compactor.selectorLabels" -}}
+{{ include "quickwit.selectorLabels" . }}
+app.kubernetes.io/component: compactor
+{{- end }}
+
 {{/*
 Create the name of the service account to use
 */}}
@@ -184,6 +191,10 @@ Quickwit environment
   value: "$(POD_IP)"
 - name: QW_CLUSTER_ENDPOINT
   value: http://{{ include "quickwit.fullname" $ }}-metastore.{{ $.Release.Namespace }}.svc.{{ .Values.clusterDomain }}:7280
+{{- if .Values.enableStandaloneCompactors }}
+- name: QW_ENABLE_STANDALONE_COMPACTORS
+  value: "true"
+{{- end }}
 {{- with (include "quickwit.extraEnv" .Values.environment) }}
 {{ . }}
 {{- end }}

--- a/charts/quickwit/templates/compactor-deployment.yaml
+++ b/charts/quickwit/templates/compactor-deployment.yaml
@@ -1,0 +1,135 @@
+{{- if .Values.enableStandaloneCompactors }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "quickwit.fullname" . }}-compactor
+  labels:
+    {{- include "quickwit.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.compactor.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  replicas: {{ .Values.compactor.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "quickwit.compactor.selectorLabels" . | nindent 6 }}
+  strategy: {{- toYaml .Values.compactor.strategy | nindent 4 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.compactor.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "quickwit.additionalLabels" . | nindent 8 }}
+        {{- include "quickwit.compactor.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "quickwit.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.compactor.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{ end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if $.Values.compactor.args }}
+          args: {{- toYaml $.Values.compactor.args | nindent 10 }}
+          {{- else }}
+          args: ["run", "--service", "compactor"]
+          {{- end }}
+          env:
+            {{- include "quickwit.environment" . | nindent 12 }}
+            {{- with (include "quickwit.extraEnv" .Values.compactor.extraEnv) }}
+            {{- . | nindent 12 }}
+            {{- end }}
+          {{- if or (.Values.environmentFrom) (.Values.compactor.extraEnvFrom) }}
+          envFrom:
+          {{- with .Values.environmentFrom }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.compactor.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- end }}
+          ports:
+            {{- include "quickwit.ports" . | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.compactor.startupProbe | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.compactor.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.compactor.readinessProbe | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /quickwit/node.yaml
+              subPath: node.yaml
+            - name: data
+              mountPath: /quickwit/qwdata
+            {{- range .Values.configMaps }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+            {{- end }}
+            {{- with .Values.compactor.extraVolumeMounts }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.compactor.resources | nindent 12 }}
+          {{- if .Values.compactor.lifecycleHooks }}
+          lifecycle:
+            {{- toYaml .Values.compactor.lifecycleHooks | nindent 12 }}
+          {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.compactor.terminationGracePeriodSeconds }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ template "quickwit.fullname" . }}
+            items:
+              - key: node.yaml
+                path: node.yaml
+        - name: data
+          emptyDir: {}
+        {{- range .Values.configMaps }}
+        - name: {{ .name }}
+          configMap:
+            name: {{ .name }}
+        {{- end }}
+        {{- with .Values.compactor.extraVolumes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.compactor.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with merge (dict) .Values.compactor.affinity .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- $tolerations := concat .Values.tolerations .Values.compactor.tolerations | compact | uniq }}
+      tolerations:
+        {{- toYaml $tolerations | nindent 8 }}
+      {{- if .Values.compactor.runtimeClassName }}
+      runtimeClassName: {{ .Values.compactor.runtimeClassName | quote }}
+      {{- end }}
+      {{- $tsc := concat .Values.topologySpreadConstraints .Values.compactor.topologySpreadConstraints | compact }}
+      {{- if $tsc }}
+      topologySpreadConstraints:
+        {{- toYaml $tsc | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/quickwit/templates/compactor-deployment.yaml
+++ b/charts/quickwit/templates/compactor-deployment.yaml
@@ -86,7 +86,7 @@ spec:
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
             {{- end }}
-            {{- with .Values.compactor.extraVolumeMounts }}
+            {{- with concat (.Values.volumeMounts | default list) (.Values.compactor.extraVolumeMounts | default list) }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
           resources:
@@ -110,7 +110,7 @@ spec:
           configMap:
             name: {{ .name }}
         {{- end }}
-        {{- with .Values.compactor.extraVolumes }}
+        {{- with concat (.Values.volumes | default list) (.Values.compactor.extraVolumes | default list) }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.compactor.nodeSelector }}

--- a/charts/quickwit/templates/compactor-pdb.yaml
+++ b/charts/quickwit/templates/compactor-pdb.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.enableStandaloneCompactors .Values.compactor.podDisruptionBudget -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "quickwit.fullname" . }}-compactor
+  labels:
+    {{- include "quickwit.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "quickwit.compactor.selectorLabels" . | nindent 6 }}
+  {{- toYaml .Values.compactor.podDisruptionBudget | nindent 2 }}
+{{- end -}}

--- a/charts/quickwit/templates/service.yaml
+++ b/charts/quickwit/templates/service.yaml
@@ -241,3 +241,45 @@ spec:
   selector:
     {{- include "quickwit.janitor.selectorLabels" . | nindent 4 }}
 {{- end }}
+---
+{{- if .Values.enableStandaloneCompactors }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "quickwit.fullname" . }}-compactor
+  labels:
+    {{- include "quickwit.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.compactor.serviceAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  type: {{ .Values.compactor.serviceType | default .Values.service.type }}
+  {{- if .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.service.ipFamilies }}
+  ipFamilies: {{ .Values.service.ipFamilies | toYaml | nindent 2 }}
+  {{- end }}
+  ports:
+    - port: 7280
+      targetPort: rest
+      protocol: TCP
+      name: rest
+      {{- $type := .Values.compactor.serviceType | default .Values.service.type }}
+      {{- if and (eq $type "NodePort") .Values.compactor.restNodePort }}
+      nodePort: {{ .Values.compactor.restNodePort }}
+      {{- end }}
+    - port: 7281
+      targetPort: grpc
+      name: grpc
+      {{- $type := .Values.compactor.serviceType | default .Values.service.type }}
+      {{- if and (eq $type "NodePort") .Values.compactor.grpcNodePort }}
+      nodePort: {{ .Values.compactor.grpcNodePort }}
+      {{- end }}
+  selector:
+    {{- include "quickwit.compactor.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -521,6 +521,112 @@ janitor:
 
   topologySpreadConstraints: []
 
+# -- Enable the standalone compactor topology.
+#
+# This is a CLUSTER-WIDE switch, not a per-pod one. When `true`:
+#   * `QW_ENABLE_STANDALONE_COMPACTORS=true` is injected into every Quickwit pod
+#     (indexers stop merging locally, the janitor starts the compaction planner).
+#   * the dedicated compactor Deployment / Service / PDB below are rendered.
+# When `false` (default), none of the compactor resources are created and merges
+# happen on the indexers exactly as before. Because the same value drives both
+# the env var and whether the workload is rendered, the compactor pods exist if
+# and only if this flag is true.
+enableStandaloneCompactors: false
+
+# Dedicated compactor workers. Only deployed when `enableStandaloneCompactors` is
+# true (there is intentionally no separate `compactor.enabled` toggle).
+compactor:
+  replicaCount: 1
+
+  # Extra env for compactor
+  # Legacy map format (e.g. extraEnv: { KEY: VALUE }) is also supported for backward compatibility.
+  extraEnv: []
+    # - name: KEY
+    #   value: VALUE
+  extraEnvFrom: []
+    # - secretRef:
+    #     name: quickwit-compactor
+    # - configMapRef:
+    #     name: quickwit-compactor
+
+  # extraVolumes -- Additional volumes to use with Pods.
+  extraVolumes: []
+
+  # extraVolumeMounts -- Additional volumes to mount into Quickwit containers.
+  extraVolumeMounts: []
+
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  ## Pod distruption budget
+  podDisruptionBudget: {}
+    # maxUnavailable: 1
+    # minAvailable: 2
+
+  strategy: {}
+    # type: RollingUpdate
+
+  startupProbe:
+    httpGet:
+      path: /health/livez
+      port: rest
+    failureThreshold: 12
+    periodSeconds: 5
+
+  livenessProbe:
+    httpGet:
+      path: /health/livez
+      port: rest
+
+  readinessProbe:
+    httpGet:
+      path: /health/readyz
+      port: rest
+
+  # Override args for starting container
+  args: []
+
+  # initContainers -- Init containers to be added to the pods
+  initContainers: []
+
+  annotations: {}
+
+  podAnnotations: {}
+
+  serviceAnnotations: {}
+
+  # serviceType: ClusterIP
+  # restNodePort:
+  # grpcNodePort:
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+  lifecycleHooks: {}
+    # preStop:
+    #   exec:
+    #     command:
+    #       - /bin/sh
+    #       - -c
+    #       - sleep 30
+
+  # Grace period to let in-flight merges finish publishing on shutdown. Unfinished
+  # merges are simply rescheduled by the planner after a heartbeat timeout, so this
+  # does not need to be as long as the indexer's.
+  terminationGracePeriodSeconds: 60
+
+  runtimeClassName: ""
+
+  topologySpreadConstraints: []
+
 # Deploy jobs to bootstrap creation of indexes and sources for quickwit clusters
 bootstrap:
   # Enable bootstrap jobs


### PR DESCRIPTION
This change is alongside https://github.com/quickwit-oss/quickwit/pull/6461. It adds the enable_standalone_compactor flag. When enabled, it affects three Quickwit services:
* The janitor, which then starts the merge planner service
* Indexers, which don't spawn merge pipelines as a result
* Compactors, which now spawn

As far as the helm chart goes, when false this change is a no-op. When true, it adds the `compactor` service and defines it similarly to other deployments in this chart. It also injects the QW_ENABLE_STANDALONE_COMPACTORS env var to all services as true.