### PR TITLE
feat(quickwit): add VolumeAttributesClass support with auto-detected apiVersion

### DIFF
--- a/charts/quickwit/Chart.yaml
+++ b/charts/quickwit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: quickwit
 description: Sub-second search & analytics engine on cloud storage.
 type: application
-version: 0.8.6
+version: 0.8.7
 appVersion: v0.8.2
 keywords:
   - quickwit

--- a/charts/quickwit/templates/_helpers.tpl
+++ b/charts/quickwit/templates/_helpers.tpl
@@ -101,6 +101,20 @@ app.kubernetes.io/component: indexer
 {{- end }}
 
 {{/*
+VolumeAttributesClass name for the indexer.
+*/}}
+{{- define "quickwit.indexer.vacName" -}}
+{{- printf "%s-indexer-vac" .Release.Name }}
+{{- end }}
+
+{{/*
+VolumeAttributesClass name for the searcher.
+*/}}
+{{- define "quickwit.searcher.vacName" -}}
+{{- printf "%s-searcher-vac" .Release.Name }}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "quickwit.serviceAccountName" -}}

--- a/charts/quickwit/templates/_helpers.tpl
+++ b/charts/quickwit/templates/_helpers.tpl
@@ -115,6 +115,19 @@ VolumeAttributesClass name for the searcher.
 {{- end }}
 
 {{/*
+VolumeAttributesClass apiVersion, auto-detected from cluster capabilities.
+*/}}
+{{- define "quickwit.volumeAttributesClass.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "storage.k8s.io/v1/VolumeAttributesClass" -}}
+storage.k8s.io/v1
+{{- else if .Capabilities.APIVersions.Has "storage.k8s.io/v1beta1/VolumeAttributesClass" -}}
+storage.k8s.io/v1beta1
+{{- else -}}
+{{- fail "VolumeAttributesClass is not available on this cluster (requires Kubernetes >= 1.31)" }}
+{{- end -}}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "quickwit.serviceAccountName" -}}

--- a/charts/quickwit/templates/indexer-statefulset.yaml
+++ b/charts/quickwit/templates/indexer-statefulset.yaml
@@ -158,7 +158,7 @@ spec:
       {{- if .Values.indexer.persistentVolume.storageClass }}
         storageClassName: "{{ .Values.indexer.persistentVolume.storageClass }}"
       {{- end }}
-      {{- if and .Values.indexer.persistentVolume.volumeAttributesClassDriver (or .Values.indexer.persistentVolume.iops .Values.indexer.persistentVolume.throughput) }}
+      {{- if and .Values.indexer.volumeAttributesClass.enabled .Values.indexer.volumeAttributesClass.driverName }}
         volumeAttributesClassName: {{ include "quickwit.indexer.vacName" . | quote }}
       {{- end }}
   {{- end }}

--- a/charts/quickwit/templates/indexer-statefulset.yaml
+++ b/charts/quickwit/templates/indexer-statefulset.yaml
@@ -158,7 +158,7 @@ spec:
       {{- if .Values.indexer.persistentVolume.storageClass }}
         storageClassName: "{{ .Values.indexer.persistentVolume.storageClass }}"
       {{- end }}
-      {{- if and .Values.indexer.volumeAttributesClass.enabled .Values.indexer.volumeAttributesClass.driverName }}
+      {{- if .Values.indexer.volumeAttributesClass.enabled }}
         volumeAttributesClassName: {{ include "quickwit.indexer.vacName" . | quote }}
       {{- end }}
   {{- end }}

--- a/charts/quickwit/templates/indexer-statefulset.yaml
+++ b/charts/quickwit/templates/indexer-statefulset.yaml
@@ -158,5 +158,8 @@ spec:
       {{- if .Values.indexer.persistentVolume.storageClass }}
         storageClassName: "{{ .Values.indexer.persistentVolume.storageClass }}"
       {{- end }}
+      {{- if and .Values.indexer.persistentVolume.volumeAttributesClassDriver (or .Values.indexer.persistentVolume.iops .Values.indexer.persistentVolume.throughput) }}
+        volumeAttributesClassName: {{ include "quickwit.indexer.vacName" . | quote }}
+      {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/quickwit/templates/searcher-statefulset.yaml
+++ b/charts/quickwit/templates/searcher-statefulset.yaml
@@ -160,5 +160,8 @@ spec:
       {{- if .Values.searcher.persistentVolume.storageClass }}
         storageClassName: "{{ .Values.searcher.persistentVolume.storageClass }}"
       {{- end }}
+      {{- if and .Values.searcher.persistentVolume.volumeAttributesClassDriver (or .Values.searcher.persistentVolume.iops .Values.searcher.persistentVolume.throughput) }}
+        volumeAttributesClassName: {{ include "quickwit.searcher.vacName" . | quote }}
+      {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/quickwit/templates/searcher-statefulset.yaml
+++ b/charts/quickwit/templates/searcher-statefulset.yaml
@@ -160,7 +160,7 @@ spec:
       {{- if .Values.searcher.persistentVolume.storageClass }}
         storageClassName: "{{ .Values.searcher.persistentVolume.storageClass }}"
       {{- end }}
-      {{- if and .Values.searcher.persistentVolume.volumeAttributesClassDriver (or .Values.searcher.persistentVolume.iops .Values.searcher.persistentVolume.throughput) }}
+      {{- if and .Values.searcher.volumeAttributesClass.enabled .Values.searcher.volumeAttributesClass.driverName }}
         volumeAttributesClassName: {{ include "quickwit.searcher.vacName" . | quote }}
       {{- end }}
   {{- end }}

--- a/charts/quickwit/templates/searcher-statefulset.yaml
+++ b/charts/quickwit/templates/searcher-statefulset.yaml
@@ -160,7 +160,7 @@ spec:
       {{- if .Values.searcher.persistentVolume.storageClass }}
         storageClassName: "{{ .Values.searcher.persistentVolume.storageClass }}"
       {{- end }}
-      {{- if and .Values.searcher.volumeAttributesClass.enabled .Values.searcher.volumeAttributesClass.driverName }}
+      {{- if .Values.searcher.volumeAttributesClass.enabled }}
         volumeAttributesClassName: {{ include "quickwit.searcher.vacName" . | quote }}
       {{- end }}
   {{- end }}

--- a/charts/quickwit/templates/volumeattributesclass.yaml
+++ b/charts/quickwit/templates/volumeattributesclass.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.indexer.persistentVolume.volumeAttributesClassDriver (or .Values.indexer.persistentVolume.iops .Values.indexer.persistentVolume.throughput) }}
+apiVersion: storage.k8s.io/v1beta1
+kind: VolumeAttributesClass
+metadata:
+  name: {{ include "quickwit.indexer.vacName" . }}
+driverName: {{ .Values.indexer.persistentVolume.volumeAttributesClassDriver }}
+parameters:
+  {{- if .Values.indexer.persistentVolume.iops }}
+  iops: {{ .Values.indexer.persistentVolume.iops | quote }}
+  {{- end }}
+  {{- if .Values.indexer.persistentVolume.throughput }}
+  throughput: {{ .Values.indexer.persistentVolume.throughput | quote }}
+  {{- end }}
+{{- end }}
+{{- if and .Values.searcher.persistentVolume.volumeAttributesClassDriver (or .Values.searcher.persistentVolume.iops .Values.searcher.persistentVolume.throughput) }}
+---
+apiVersion: storage.k8s.io/v1beta1
+kind: VolumeAttributesClass
+metadata:
+  name: {{ include "quickwit.searcher.vacName" . }}
+driverName: {{ .Values.searcher.persistentVolume.volumeAttributesClassDriver }}
+parameters:
+  {{- if .Values.searcher.persistentVolume.iops }}
+  iops: {{ .Values.searcher.persistentVolume.iops | quote }}
+  {{- end }}
+  {{- if .Values.searcher.persistentVolume.throughput }}
+  throughput: {{ .Values.searcher.persistentVolume.throughput | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/quickwit/templates/volumeattributesclass.yaml
+++ b/charts/quickwit/templates/volumeattributesclass.yaml
@@ -1,29 +1,23 @@
-{{- if and .Values.indexer.persistentVolume.volumeAttributesClassDriver (or .Values.indexer.persistentVolume.iops .Values.indexer.persistentVolume.throughput) }}
-apiVersion: storage.k8s.io/v1beta1
+{{- if and .Values.indexer.volumeAttributesClass.enabled .Values.indexer.volumeAttributesClass.driverName }}
+apiVersion: {{ include "quickwit.volumeAttributesClass.apiVersion" . }}
 kind: VolumeAttributesClass
 metadata:
   name: {{ include "quickwit.indexer.vacName" . }}
-driverName: {{ .Values.indexer.persistentVolume.volumeAttributesClassDriver }}
+driverName: {{ .Values.indexer.volumeAttributesClass.driverName }}
+{{- with .Values.indexer.volumeAttributesClass.parameters }}
 parameters:
-  {{- if .Values.indexer.persistentVolume.iops }}
-  iops: {{ .Values.indexer.persistentVolume.iops | quote }}
-  {{- end }}
-  {{- if .Values.indexer.persistentVolume.throughput }}
-  throughput: {{ .Values.indexer.persistentVolume.throughput | quote }}
-  {{- end }}
+  {{- toYaml . | nindent 2 }}
 {{- end }}
-{{- if and .Values.searcher.persistentVolume.volumeAttributesClassDriver (or .Values.searcher.persistentVolume.iops .Values.searcher.persistentVolume.throughput) }}
+{{- end }}
+{{- if and .Values.searcher.volumeAttributesClass.enabled .Values.searcher.volumeAttributesClass.driverName }}
 ---
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: {{ include "quickwit.volumeAttributesClass.apiVersion" . }}
 kind: VolumeAttributesClass
 metadata:
   name: {{ include "quickwit.searcher.vacName" . }}
-driverName: {{ .Values.searcher.persistentVolume.volumeAttributesClassDriver }}
+driverName: {{ .Values.searcher.volumeAttributesClass.driverName }}
+{{- with .Values.searcher.volumeAttributesClass.parameters }}
 parameters:
-  {{- if .Values.searcher.persistentVolume.iops }}
-  iops: {{ .Values.searcher.persistentVolume.iops | quote }}
-  {{- end }}
-  {{- if .Values.searcher.persistentVolume.throughput }}
-  throughput: {{ .Values.searcher.persistentVolume.throughput | quote }}
-  {{- end }}
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/quickwit/templates/volumeattributesclass.yaml
+++ b/charts/quickwit/templates/volumeattributesclass.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.indexer.volumeAttributesClass.enabled .Values.indexer.volumeAttributesClass.driverName }}
+{{- if .Values.indexer.volumeAttributesClass.enabled }}
 apiVersion: {{ include "quickwit.volumeAttributesClass.apiVersion" . }}
 kind: VolumeAttributesClass
 metadata:
@@ -9,7 +9,7 @@ parameters:
   {{- toYaml . | nindent 2 }}
 {{- end }}
 {{- end }}
-{{- if and .Values.searcher.volumeAttributesClass.enabled .Values.searcher.volumeAttributesClass.driverName }}
+{{- if .Values.searcher.volumeAttributesClass.enabled }}
 ---
 apiVersion: {{ include "quickwit.volumeAttributesClass.apiVersion" . }}
 kind: VolumeAttributesClass

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -113,6 +113,9 @@ searcher:
     annotations: {}
     # storage: "1Gi"
     # storageClass: ""
+    # iops: ""
+    # throughput: ""
+    # volumeAttributesClassDriver: ""
 
   updateStrategy: {}
     # type: RollingUpdate
@@ -274,6 +277,9 @@ indexer:
     annotations: {}
     # storage: "1Gi"
     # storageClass: ""
+    # iops: ""
+    # throughput: ""
+    # volumeAttributesClassDriver: ""
 
   topologySpreadConstraints: []
 

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -116,6 +116,7 @@ searcher:
 
   volumeAttributesClass:
     enabled: false
+    # driverName is mandatory when volumeAttributesClass is enabled.
     # driverName: ebs.csi.aws.com
     # parameters:
     #   iops: "3000"
@@ -284,6 +285,7 @@ indexer:
 
   volumeAttributesClass:
     enabled: false
+    # driverName is mandatory when volumeAttributesClass is enabled.
     # driverName: ebs.csi.aws.com
     # parameters:
     #   iops: "3000"

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -113,9 +113,13 @@ searcher:
     annotations: {}
     # storage: "1Gi"
     # storageClass: ""
-    # iops: ""
-    # throughput: ""
-    # volumeAttributesClassDriver: ""
+
+  volumeAttributesClass:
+    enabled: false
+    # driverName: ebs.csi.aws.com
+    # parameters:
+    #   iops: "3000"
+    #   throughput: "125"
 
   updateStrategy: {}
     # type: RollingUpdate
@@ -277,9 +281,13 @@ indexer:
     annotations: {}
     # storage: "1Gi"
     # storageClass: ""
-    # iops: ""
-    # throughput: ""
-    # volumeAttributesClassDriver: ""
+
+  volumeAttributesClass:
+    enabled: false
+    # driverName: ebs.csi.aws.com
+    # parameters:
+    #   iops: "3000"
+    #   throughput: "125"
 
   topologySpreadConstraints: []
 


### PR DESCRIPTION
## Summary

This PR adds support for [VolumeAttributesClass](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/) (Kubernetes 1.31+ beta feature), enabling dynamic modification of storage performance parameters (IOPS and throughput) on existing persistent volumes without recreating them.

### New values structure

A dedicated `volumeAttributesClass` block is available as a sibling to `persistentVolume` under both `indexer` and `searcher`:

```yaml
indexer:
  persistentVolume:
    enabled: true
    storage: 1Gi
  volumeAttributesClass:
    enabled: true
    driverName: ebs.csi.aws.com
    parameters:
      iops: "3000"
      throughput: "125"

searcher:
  persistentVolume:
    enabled: true
    storage: 1Gi
  volumeAttributesClass:
    enabled: true
    driverName: ebs.csi.aws.com
    parameters:
      iops: "6000"
      throughput: "250"
```

The `parameters` field is a free-form map, so any driver-specific key/value pairs are supported beyond just `iops` and `throughput`.

When `enabled: true` and `driverName` is set, the chart creates a `VolumeAttributesClass` resource and references it in the StatefulSet's PVC template.

### Auto-detected apiVersion

The chart automatically selects the right `apiVersion` based on what the cluster supports, with a clear error if neither is available:

- `storage.k8s.io/v1` (when available — future stable release)
- `storage.k8s.io/v1beta1` (Kubernetes 1.31+, current default)
- Fails with a descriptive error on unsupported clusters

### Cloud provider examples

- **GKE**: `pd.csi.storage.gke.io` — [docs](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/gce-pd-csi-driver#create_a_volumeattributesclass_to_define_performance_tiers)
- **EKS**: `ebs.csi.aws.com` — [docs](https://aws.amazon.com/blogs/containers/modify-amazon-ebs-volumes-on-kubernetes-with-volume-attributes-classes/)
- **AKS**: `azuredisk-csi-driver` — [driver parameters](https://github.com/kubernetes-sigs/azuredisk-csi-driver/tree/3d4d99fd86f21e5d8e73f072c02e7a95446b10f0/deploy/example/modifyvolume)

## Breaking change

**No breaking change.** The `volumeAttributesClass` block is opt-in (`enabled: false` by default). Existing deployments are unaffected.

## Applying to an existing release

Because `VolumeAttributesClass` is designed to modify volume performance **in place**, no data migration or PVC recreation is required. However, Kubernetes considers StatefulSet `volumeClaimTemplates` immutable, so a plain `helm upgrade` will be rejected with a `Forbidden: updates to statefulset spec` error. Two workarounds are available:

### Option A — Patch existing PVCs directly (recommended, zero downtime)

`VolumeAttributesClass` can be bound directly to existing PVCs without touching the StatefulSet. This is the preferred approach as it requires no pod disruption:

```bash
# 1. Apply the chart to create the VolumeAttributesClass resources (the StatefulSet update will fail, that's expected)
helm upgrade <release-name> quickwit/quickwit -f values.yaml || true

# 2. Patch each PVC to reference the new VolumeAttributesClass
kubectl patch pvc <pvc-name>-0 -p '{"spec": {"volumeAttributesClassName": "<release-name>-indexer-vac"}}'
kubectl patch pvc <pvc-name>-0 -p '{"spec": {"volumeAttributesClassName": "<release-name>-searcher-vac"}}'
```

The CSI driver will then apply the new performance attributes in place. The StatefulSet does not need to be updated since the PVCs are already bound — the `volumeAttributesClassName` in the PVC template only takes effect for **newly created** PVCs.

### Option B — Delete StatefulSets with orphan cascade, then upgrade

This keeps the StatefulSet definition in sync with the chart but causes a brief pod rollout:

```bash
# 1. Delete StatefulSets without deleting pods or PVCs
kubectl delete statefulset <release-name>-indexer --cascade=orphan
kubectl delete statefulset <release-name>-searcher --cascade=orphan

# 2. Run helm upgrade — Helm recreates the StatefulSets with the volumeAttributesClassName field
helm upgrade <release-name> quickwit/quickwit -f values.yaml
```

Pods are rolled out normally after the upgrade. PVCs and their data are untouched.

---

> **Requires Kubernetes 1.31+** with the `VolumeAttributesClass` feature gate enabled (on by default as beta in 1.31).