### PR TITLE
Add optional AZ awareness topology constraints

### DIFF
--- a/charts/quickwit/Chart.yaml
+++ b/charts/quickwit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: quickwit
 description: Sub-second search & analytics engine on cloud storage.
 type: application
-version: 0.8.7
+version: 0.8.8
 appVersion: v0.8.2
 keywords:
   - quickwit

--- a/charts/quickwit/templates/_helpers.tpl
+++ b/charts/quickwit/templates/_helpers.tpl
@@ -209,3 +209,16 @@ List format (recommended): [{ name: KEY, value: VALUE, valueFrom: ... }]
 {{- end -}}
 {{- end -}}
 {{- end }}
+
+{{/*
+AZ awareness topology spread constraint for a component.
+Accepts the component's selector labels YAML string as its argument.
+*/}}
+{{- define "quickwit.azTopologySpreadConstraint" -}}
+- maxSkew: 1
+  topologyKey: topology.kubernetes.io/zone
+  whenUnsatisfiable: ScheduleAnyway
+  labelSelector:
+    matchLabels:
+      {{- . | nindent 6 }}
+{{- end }}

--- a/charts/quickwit/templates/indexer-statefulset.yaml
+++ b/charts/quickwit/templates/indexer-statefulset.yaml
@@ -137,9 +137,14 @@ spec:
       runtimeClassName: {{ .Values.indexer.runtimeClassName | quote }}
       {{- end }}
       {{- $tsc := concat .Values.topologySpreadConstraints .Values.indexer.topologySpreadConstraints | compact }}
-      {{- if $tsc }}
+      {{- if or $tsc .Values.azAwareness.enabled }}
       topologySpreadConstraints:
-        {{- toYaml $tsc | nindent 8 }}
+        {{- if .Values.azAwareness.enabled }}
+        {{- include "quickwit.azTopologySpreadConstraint" (include "quickwit.indexer.selectorLabels" .) | nindent 8 }}
+        {{- end }}
+        {{- with $tsc }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
   {{- if .Values.indexer.persistentVolume.enabled }}
   volumeClaimTemplates:

--- a/charts/quickwit/templates/service.yaml
+++ b/charts/quickwit/templates/service.yaml
@@ -84,6 +84,9 @@ metadata:
   labels:
     {{- include "quickwit.labels" . | nindent 4 }}
   annotations:
+    {{- if .Values.azAwareness.enabled }}
+    service.kubernetes.io/topology-mode: Auto
+    {{- end }}
     {{- with .Values.service.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -74,6 +74,14 @@ volumeMounts: []
 # -- Configure [topology spread constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/).
 topologySpreadConstraints: []
 
+# Availability Zone awareness
+azAwareness:
+  # -- Enable AZ awareness. Adds a topology spread constraint to distribute indexer pods
+  # evenly across zones, and enables topology-aware routing on the indexer service so
+  # traffic prefers same-zone endpoints. Uses the node-level `topology.kubernetes.io/zone`
+  # label.
+  enabled: false
+
 searcher:
   enabled: true
   replicaCount: 3


### PR DESCRIPTION
Adds AZ aware routing to the Quickwit Indexer Kubernetes service. The actual API for getting the AZ from a node is only default-enabled as of Kubernetes 1.35. It's off by default and is opt-in.