### PR TITLE
Preserve explicit metastore read replica configuration

### DIFF
--- a/charts/quickwit/Chart.yaml
+++ b/charts/quickwit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: quickwit
 description: Sub-second search & analytics engine on cloud storage.
 type: application
-version: 0.8.9
+version: 0.8.10
 appVersion: v0.8.2
 keywords:
   - quickwit

--- a/charts/quickwit/templates/configmap.yaml
+++ b/charts/quickwit/templates/configmap.yaml
@@ -1,7 +1,16 @@
 {{- $config := deepCopy .Values.config -}}
 {{- if .Values.metastore_ro.enabled -}}
 {{- $searcherConfig := $config.searcher | default dict -}}
+{{- /*
+Preserve an explicit value so a read-only metastore can be disabled safely:
+first set use_metastore_read_replica to false while metastore_ro remains
+enabled, wait for all searchers to use the primary metastore, then disable
+metastore_ro. Disabling metastore_ro first would shut down a replica that
+searchers may still be using.
+*/ -}}
+{{- if not (hasKey $searcherConfig "use_metastore_read_replica") -}}
 {{- $_ := set $searcherConfig "use_metastore_read_replica" true -}}
+{{- end -}}
 {{- $_ := set $config "searcher" $searcherConfig -}}
 {{- end -}}
 apiVersion: v1


### PR DESCRIPTION
## Summary
- preserve an explicitly configured `use_metastore_read_replica` value