### PR TITLE
Add HorizontalPodAutoscaler for indexer, searcher, and compactor

### DIFF
--- a/charts/quickwit/Chart.yaml
+++ b/charts/quickwit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: quickwit
 description: Sub-second search & analytics engine on cloud storage.
 type: application
-version: 0.8.10
+version: 0.8.11
 appVersion: v0.8.2
 keywords:
   - quickwit

--- a/charts/quickwit/templates/compactor-deployment.yaml
+++ b/charts/quickwit/templates/compactor-deployment.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- if not .Values.compactor.autoscaling.enabled }}
+  {{- if and (hasKey .Values.compactor "replicaCount") (not .Values.compactor.autoscaling.enabled) }}
   replicas: {{ .Values.compactor.replicaCount }}
   {{- end }}
   selector:

--- a/charts/quickwit/templates/compactor-deployment.yaml
+++ b/charts/quickwit/templates/compactor-deployment.yaml
@@ -13,7 +13,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  {{- if not .Values.compactor.autoscaling.enabled }}
   replicas: {{ .Values.compactor.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "quickwit.compactor.selectorLabels" . | nindent 6 }}

--- a/charts/quickwit/templates/hpa.yaml
+++ b/charts/quickwit/templates/hpa.yaml
@@ -1,0 +1,80 @@
+{{- if .Values.indexer.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "quickwit.fullname" . }}-indexer
+  labels:
+    {{- include "quickwit.labels" . | nindent 4 }}
+    app.kubernetes.io/component: indexer-hpa
+  {{- with .Values.indexer.autoscaling.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: {{ include "quickwit.fullname" . }}-indexer
+  minReplicas: {{ .Values.indexer.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.indexer.autoscaling.maxReplicas }}
+  metrics:
+    {{- toYaml .Values.indexer.autoscaling.metrics | nindent 4 }}
+  {{- if .Values.indexer.autoscaling.behavior }}
+  behavior:
+    {{- toYaml .Values.indexer.autoscaling.behavior | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- if .Values.searcher.autoscaling.enabled }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "quickwit.fullname" . }}-searcher
+  labels:
+    {{- include "quickwit.labels" . | nindent 4 }}
+    app.kubernetes.io/component: searcher-hpa
+  {{- with .Values.searcher.autoscaling.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: {{ include "quickwit.fullname" . }}-searcher
+  minReplicas: {{ .Values.searcher.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.searcher.autoscaling.maxReplicas  }}
+  metrics:
+    {{- toYaml .Values.searcher.autoscaling.metrics | nindent 4 }}
+  {{- if .Values.searcher.autoscaling.behavior }}
+  behavior:
+    {{- toYaml .Values.searcher.autoscaling.behavior | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- if and .Values.enableStandaloneCompactors .Values.compactor.autoscaling.enabled }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "quickwit.fullname" . }}-compactor
+  labels:
+    {{- include "quickwit.labels" . | nindent 4 }}
+    app.kubernetes.io/component: compactor-hpa
+  {{- with .Values.compactor.autoscaling.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "quickwit.fullname" . }}-compactor
+  minReplicas: {{ .Values.compactor.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.compactor.autoscaling.maxReplicas }}
+  metrics:
+    {{- toYaml .Values.compactor.autoscaling.metrics | nindent 4 }}
+  {{- if .Values.compactor.autoscaling.behavior }}
+  behavior:
+    {{- toYaml .Values.compactor.autoscaling.behavior | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/quickwit/templates/indexer-statefulset.yaml
+++ b/charts/quickwit/templates/indexer-statefulset.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- if hasKey .Values.indexer "replicaCount" }}
+  {{- if and (hasKey .Values.indexer "replicaCount") (not .Values.indexer.autoscaling.enabled) }}
   replicas: {{ .Values.indexer.replicaCount }}
   {{- end }}
   serviceName: {{ include "quickwit.fullname" . }}-headless

--- a/charts/quickwit/templates/searcher-statefulset.yaml
+++ b/charts/quickwit/templates/searcher-statefulset.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- if hasKey .Values.searcher "replicaCount" }}
+  {{- if and (hasKey .Values.searcher "replicaCount") (not .Values.searcher.autoscaling.enabled) }}
   replicas: {{ .Values.searcher.replicaCount }}
   {{- end }}
   serviceName: {{ include "quickwit.fullname" . }}-headless

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -94,9 +94,9 @@ searcher:
           target:
             type: Utilization
             averageUtilization: 50
-    behavior: {}
-      # scaleUp:
-      #   stabilizationWindowSeconds: 60
+    behavior:
+      scaleUp:
+        stabilizationWindowSeconds: 60
       # scaleDown:
       #   stabilizationWindowSeconds: 300
 
@@ -223,9 +223,9 @@ indexer:
           target:
             type: Utilization
             averageUtilization: 80
-    behavior: {}
-      # scaleUp:
-      #   stabilizationWindowSeconds: 60
+    behavior:
+      scaleUp:
+        stabilizationWindowSeconds: 60
       # scaleDown:
       #   stabilizationWindowSeconds: 300
 
@@ -680,9 +680,9 @@ compactor:
           target:
             type: Utilization
             averageUtilization: 80
-    behavior: {}
-      # scaleUp:
-      #   stabilizationWindowSeconds: 60
+    behavior:
+      scaleUp:
+        stabilizationWindowSeconds: 60
       # scaleDown:
       #   stabilizationWindowSeconds: 300
 

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -76,7 +76,29 @@ topologySpreadConstraints: []
 
 searcher:
   enabled: true
+
+  # When autoscaling is enabled, replicaCount is ignored.
   replicaCount: 3
+
+  # Enable and configure autoscaling using Horizontal Pod Autoscaler (HPA)
+  autoscaling:
+    enabled: false
+    annotations: {}
+    minReplicas: 3
+    maxReplicas: 10
+    metrics:
+      # Search is a "latency game", so we aim for low CPU utilization
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 50
+    behavior: {}
+      # scaleUp:
+      #   stabilizationWindowSeconds: 60
+      # scaleDown:
+      #   stabilizationWindowSeconds: 300
 
   # Extra env for searcher
   # Legacy map format (e.g. extraEnv: { KEY: VALUE }) is also supported for backward compatibility.
@@ -184,7 +206,28 @@ searcher:
 indexer:
   enabled: true
 
+  # When autoscaling is enabled, replicaCount is ignored.
   replicaCount: 1
+
+  # Enable and configure autoscaling using Horizontal Pod Autoscaler (HPA)
+  autoscaling:
+    enabled: false
+    annotations: {}
+    minReplicas: 1
+    maxReplicas: 10
+    metrics:
+      # Indexing is a "throughput game", so we aim for high CPU utilization
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 80
+    behavior: {}
+      # scaleUp:
+      #   stabilizationWindowSeconds: 60
+      # scaleDown:
+      #   stabilizationWindowSeconds: 300
 
   # Extra env for indexer
   # Legacy map format (e.g. extraEnv: { KEY: VALUE }) is also supported for backward compatibility.
@@ -619,7 +662,29 @@ enableStandaloneCompactors: false
 # Dedicated compactor workers. Only deployed when `enableStandaloneCompactors` is
 # true (there is intentionally no separate `compactor.enabled` toggle).
 compactor:
+  # When autoscaling is enabled, replicaCount is ignored.
   replicaCount: 1
+
+  # Enable and configure autoscaling using Horizontal Pod Autoscaler (HPA).
+  # Only takes effect when `enableStandaloneCompactors` is also true.
+  autoscaling:
+    enabled: false
+    annotations: {}
+    minReplicas: 1
+    maxReplicas: 10
+    metrics:
+      # Compaction is a "throughput game", so we aim for high CPU utilization
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 80
+    behavior: {}
+      # scaleUp:
+      #   stabilizationWindowSeconds: 60
+      # scaleDown:
+      #   stabilizationWindowSeconds: 300
 
   # Extra env for compactor
   # Legacy map format (e.g. extraEnv: { KEY: VALUE }) is also supported for backward compatibility.


### PR DESCRIPTION
Adds optional HPA support (autoscaling.enabled) for the indexer and searcher StatefulSets and the standalone compactor Deployment, so replica counts can scale with CPU utilization instead of being fixed.