### PR TITLE
Allow externally managed VolumeAttributesClass references

### DIFF
--- a/charts/quickwit/Chart.yaml
+++ b/charts/quickwit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: quickwit
 description: Sub-second search & analytics engine on cloud storage.
 type: application
-version: 0.8.13
+version: 0.8.14
 appVersion: v0.8.2
 keywords:
   - quickwit

--- a/charts/quickwit/templates/indexer-statefulset.yaml
+++ b/charts/quickwit/templates/indexer-statefulset.yaml
@@ -161,7 +161,9 @@ spec:
       {{- if .Values.indexer.persistentVolume.storageClass }}
         storageClassName: "{{ .Values.indexer.persistentVolume.storageClass }}"
       {{- end }}
-      {{- if .Values.indexer.volumeAttributesClass.enabled }}
+      {{- if .Values.indexer.persistentVolume.volumeAttributesClassName }}
+        volumeAttributesClassName: {{ .Values.indexer.persistentVolume.volumeAttributesClassName | quote }}
+      {{- else if .Values.indexer.volumeAttributesClass.enabled }}
         volumeAttributesClassName: {{ include "quickwit.indexer.vacName" . | quote }}
       {{- end }}
   {{- end }}

--- a/charts/quickwit/templates/searcher-statefulset.yaml
+++ b/charts/quickwit/templates/searcher-statefulset.yaml
@@ -160,7 +160,9 @@ spec:
       {{- if .Values.searcher.persistentVolume.storageClass }}
         storageClassName: "{{ .Values.searcher.persistentVolume.storageClass }}"
       {{- end }}
-      {{- if .Values.searcher.volumeAttributesClass.enabled }}
+      {{- if .Values.searcher.persistentVolume.volumeAttributesClassName }}
+        volumeAttributesClassName: {{ .Values.searcher.persistentVolume.volumeAttributesClassName | quote }}
+      {{- else if .Values.searcher.volumeAttributesClass.enabled }}
         volumeAttributesClassName: {{ include "quickwit.searcher.vacName" . | quote }}
       {{- end }}
   {{- end }}

--- a/charts/quickwit/values.yaml
+++ b/charts/quickwit/values.yaml
@@ -133,6 +133,8 @@ searcher:
     annotations: {}
     # storage: "1Gi"
     # storageClass: ""
+    # -- Name of an externally managed VolumeAttributesClass to use for the persistent volume.
+    volumeAttributesClassName: ""
 
   volumeAttributesClass:
     enabled: false
@@ -320,6 +322,8 @@ indexer:
     annotations: {}
     # storage: "1Gi"
     # storageClass: ""
+    # -- Name of an externally managed VolumeAttributesClass to use for the persistent volume.
+    volumeAttributesClassName: ""
 
   volumeAttributesClass:
     enabled: false


### PR DESCRIPTION
## Summary
- add `persistentVolume.volumeAttributesClassName` values for indexer and searcher claims
- prefer externally managed VolumeAttributesClass references when configured